### PR TITLE
Migration des données ecolab-transport

### DIFF
--- a/data/actions/transport.yaml
+++ b/data/actions/transport.yaml
@@ -171,30 +171,6 @@ transport . boulot . commun . type . métro:
 transport . boulot . commun . type . tramway:
 transport . boulot . commun . type . TER:
 
-transport . bus . empreinte:
-  formule: 0.129
-  unité: kgCO2e/km 
-  description: |
-    Base Carbone consultée le 02/10/20 Autobus moyen - Agglomération de plus de 250 000 habitants
-
-transport . TER . empreinte:
-  formule: 0.0248
-  unité: kgCO2e/km 
-  description: |
-    Base Carbone consultée le 02/10/20 TER - 2019 - Traction moyenne 
-  
-transport . métro . empreinte:
-  formule: 0.0025
-  unité: kgCO2e/km 
-  description: |
-    Base Carbone consultée le 02/10/20 Métro - 2019 - Île-de-France
-
-transport . tramway . empreinte:
-  formule: 0.0022
-  unité: kgCO2e/km 
-  description: |
-    Base Carbone consultée le 02/10/20 Tramway - 2019 - Île-de-France
-
 transport . boulot . télétravail: 
   titre: Faire du télétravail
   icônes: 🏠💻

--- a/data/transport.yaml
+++ b/data/transport.yaml
@@ -78,11 +78,6 @@ transport . voiture . thermique . empreinte au kilomètre:
   formule: consommation au kilomètre * empreinte au litre
 
 transport . voiture . électrique:
-transport . voiture . électrique . empreinte au kilomètre:
-  titre: empreinte au km électrique
-  formule: 0.020
-  unité: kgCO2e/km
-  note: Pas de variations en fonction de la taille de la voiture, il nous faudra trouver ces donnnées
 
 transport . voiture . impact usage:
   formule: km * empreinte au kilomètre

--- a/transport . empreinte.yaml
+++ b/transport . empreinte.yaml
@@ -1,0 +1,24 @@
+transport . bus . empreinte:
+  formule: 0.129
+  unité: kgCO2e/km 
+  description: |
+    Base Carbone consultée le 02/10/20 Autobus moyen - Agglomération de plus de 250 000 habitants
+
+transport . TER . empreinte:
+  formule: 0.0248
+  unité: kgCO2e/km 
+  description: |
+    Base Carbone consultée le 02/10/20 TER - 2019 - Traction moyenne 
+  
+transport . métro . empreinte:
+  formule: 0.0025
+  unité: kgCO2e/km 
+  description: |
+    Base Carbone consultée le 02/10/20 Métro - 2019 - Île-de-France
+
+transport . tramway . empreinte:
+  formule: 0.0022
+  unité: kgCO2e/km 
+  description: |
+    Base Carbone consultée le 02/10/20 Tramway - 2019 - Île-de-France
+

--- a/transport . empreinte.yaml
+++ b/transport . empreinte.yaml
@@ -22,3 +22,8 @@ transport . tramway . empreinte:
   description: |
     Base Carbone consultée le 02/10/20 Tramway - 2019 - Île-de-France
 
+transport . voiture . électrique . empreinte au kilomètre:
+  titre: empreinte au km électrique
+  formule: 0.020
+  unité: kgCO2e/km
+  note: Pas de variations en fonction de la taille de la voiture, il nous faudra trouver ces donnnées


### PR DESCRIPTION
Accueil des données de ecolab-transport dans un nouveau fichier yaml, qui sera exposé sans le reste des règles pour que ecolab-transport puisse charger les facteurs d'émission du transport.

Reste donc notamment à transférer tous les FE en les intégrant en publicodes (et fusionner ceux qui se recoupent) et en gardant les attributs nécessaires, par exemple dans un attribut de règle nouveau "ecolab-transport".

Bonus : ça nous fera une documentation Web unifiée qu'on pourra référence dans ecolab-transport / ailleurs.