### PR TITLE
listing biens électroménagers

### DIFF
--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -89,7 +89,7 @@ divers . lave linge . durée:
   unité: ans
 divers . lave linge:
   applicable si: présent
-  icônes: 👕👗
+  icônes: 👕💧
   formule: 342 / (durée * coefficent préservation)
   unité: kgCO2e
   
@@ -193,8 +193,7 @@ divers . cafetière:
   note: On considère un aspirateur sans sac
 
 divers . électroménager . préservation:
-  question: Réparez-vous vos appareils lorsqu'il tombe en panne et faites vous en sorte de les faire durer le plus longtemps posible?
-  # Faites-vous en sorte d'allonger la durée de vie de vos appareils en les réparant lorsqu'ils tombent en panne ?
+  question: Faites-vous en sorte d'allonger la durée de vie de vos appareils en les utilisant de manière adéquate et en les réparant lorsqu'ils tombent en panne ?
   par défaut: "'non'"
   formule:
     une possibilité: 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -131,7 +131,7 @@ divers . électroménager . four . durée:
   unité: ans
 divers . électroménager . four:
   applicable si: présent
-  icônes: 🍕
+  icônes: ♨️🍕
   formule: 217 / (durée * coefficient préservation)
   unité: kgCO2e
   
@@ -143,7 +143,7 @@ divers . électroménager . micro-ondes . durée:
   unité: ans
 divers . électroménager . micro-ondes:
   applicable si: présent
-  icônes: 🥧
+  icônes: 〰️🥧
   formule: 98.4 / (durée * coefficient préservation)
   unité: kgCO2e
 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -227,23 +227,35 @@ divers . électroménager . tondeuse électrique:
 
 divers . électroménager . préservation:
   question: Quel effort faites-vous en pour garder vos appareils électroménagers le plus longtemps possible ?
-  par défaut: "'presque aucun'"
+  par défaut: "'moyen'"
   formule:
     une possibilité: 
       choix obligatoire: oui
       possibilités: 
-        - presque aucun
+        - achat neuf
+        - faible
         - moyen
         - maximum
 
-divers . électroménager . préservation . presque aucun:
+divers . électroménager . préservation . faible:
+  titre: Peu d'effort
+divers . électroménager . préservation . achat neuf:
+  titre: J'achète beaucoup de neuf
 divers . électroménager . préservation . moyen:
 divers . électroménager . préservation . maximum:
         
 divers . électroménager . coefficient préservation: 
+  note: |
+    Nous définissons une grille de comportements de consommation, de l'acheteur neuf presque compulsif à celui qui fait un effort important pour garder ses appareils le plus longtemps possible. 
+
+    L'acheteur neuf garde ses appareils la moitié de leur durée de vie moyenne constatée, à l'inverse celui qui conserve repousse une durée de vie moyenne de 10 ans à 13 ans.
+
+    Cette grille pourra évoluer si de nouvelles sources, études viennent compléter tout cela.
   formule:
     variations: 
-        - si: préservation = 'presque aucun'
+        - si: préservation = 'achat neuf'
+          alors: 1 / 2
+        - si: préservation = 'faible'
           alors: 2 / 3
         - si: préservation = 'moyen'
           alors: 1

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -42,7 +42,13 @@ divers . autres produits . montant:
 
 divers . électroménager: 
   icônes: ⚙️🏠
-  note: Nous ne comptons ici que l'empreinte de la construction des biens électroménager, car leur usage implique surtout de l'électricité, déjà comptée via la facture en kWh.
+  note: |
+    Nous ne comptons ici que l'empreinte de la construction des biens électroménager, car leur usage implique surtout de l'électricité, déjà comptée via la facture en kWh.
+
+    Nous considérons que tous les appareils électroménagers sont utilisés par l'ensemble du foyer.
+  formule: appareils / logement . habitants
+
+divers . électroménager . appareils: 
   formule:
     somme:
     - réfrigérateur

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -182,10 +182,10 @@ divers . cafetière:
  divers . aspirateur . présent:
   question: Possedez vous un aspirateur ?
   par défaut: oui
-divers . cafetière . durée:
+divers . aspirateur . durée:
   formule: 5.33
   unité: ans
-divers . cafetière:
+divers . aspirateur:
   applicable si: présent
   icônes: 💨
   formule: 52.4 / (durée * coefficent préservation)

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -42,6 +42,7 @@ divers . autres produits . montant:
 
 divers . électroménager: 
   icônes: ⚙️🏠
+  note: Nous ne comptons ici que l'empreinte de la construction des biens électroménager, car leur usage implique surtout de l'électricité, déjà comptée via la facture en kWh.
   formule:
     somme:
     - réfrigérateur
@@ -226,25 +227,25 @@ divers . électroménager . tondeuse électrique:
 
 divers . électroménager . préservation:
   question: Quel effort faites-vous en pour garder vos appareils électroménagers le plus longtemps possible ?
-  par défaut: "'presque pas'"
+  par défaut: "'presque aucun'"
   formule:
     une possibilité: 
       choix obligatoire: oui
       possibilités: 
-        - presque pas
-        - en partie
+        - presque aucun
+        - moyen
         - maximum
 
-divers . électroménager . préservation . presque pas:
-divers . électroménager . préservation . en partie:
+divers . électroménager . préservation . presque aucun:
+divers . électroménager . préservation . moyen:
 divers . électroménager . préservation . maximum:
         
 divers . électroménager . coefficient préservation: 
   formule:
     variations: 
-        - si: préservation = 'presque pas'
+        - si: préservation = 'presque aucun'
           alors: 2 / 3
-        - si: préservation = 'en partie'
+        - si: préservation = 'moyen'
           alors: 1
         - sinon: 4 / 3
 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -52,149 +52,166 @@ divers . autres produits . montant:
 
   note: Cette catégorie est assez vague, il faudrait au moins donner plus d'exemples.
   par défaut: 2000 €/an
-
-
+  
+  
 divers . réfrigérateur . présent:
   question: Possedez vous un réfrigérateur ?
-  par défaut: oui
+  par défaut: oui  
 divers . réfrigérateur . durée:
-  question: Quel âge a votre réfrigérateur ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
+  note: |
+    Les durées de vies des appareils sont calculées de manière à ce que leur multiplication par le coefficient associé à la réponse "en partie" (1.5) recoupe avec
+    [ADEME](https://www.ademe.fr/evaluation-environnementale-economique-lallongement-duree-dusage-biens-dequipements-electriques-electroniques-a-lechelle-dun-foyer) Tableau 1 page 11
 divers . réfrigérateur:
   applicable si: présent
-  icônes: 
-  formule: 257 / (durée + 1)
+  icônes: 🍅🥒
+  formule: 257 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
 divers . mini réfrigérateur . présent:
   question: Possedez vous un mini réfrigérateur ?
   par défaut: oui
 divers . mini réfrigérateur . durée:
-  question: Quel âge a votre mini réfrigérateur ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
 divers . mini réfrigérateur:
   applicable si: présent
-  icônes: 
-  formule: 87.6 / (durée + 1)
+  icônes: 🥒
+  formule: 87.6 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
 divers . lave linge . présent:
   question: Possedez vous un lave linge ?
   par défaut: oui
 divers . lave linge . durée:
-  question: Quel âge a votre lave linge ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
 divers . lave linge:
   applicable si: présent
-  icônes: 
-  formule: 342 / (durée + 1)
+  icônes: 👕👗
+  formule: 342 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
   
 divers . sèche linge . présent:
   question: Possedez vous un sèche linge ?
   par défaut: oui
 divers . sèche linge . durée:
-  question: Quel âge a votre sèche linge ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
 divers . sèche linge:
   applicable si: présent
-  icônes: 
-  formule: 266 / (durée + 1)
+  icônes: 👕♨️
+  formule: 266 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
 divers . lave vaiselle . présent:
   question: Possedez vous un lave vaiselle ?
   par défaut: oui
 divers . lave vaiselle . durée:
-  question: Quel âge a votre lave vaiselle ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
 divers . lave vaiselle:
   applicable si: présent
-  icônes: 
-  formule: 271 / (durée + 1)
+  icônes: 🍽️
+  formule: 271 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
 divers . four . présent:
   question: Possedez vous un four ?
   par défaut: oui
 divers . four . durée:
-  question: Quel âge a votre four ? 
+  formule: 8
   unité: ans
-  par défaut: 4 ans
 divers . four:
   applicable si: présent
-  icônes: 
-  formule: 217 / (durée + 1)
+  icônes: 🍕
+  formule: 217 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
   
 divers . micro onde . présent:
   question: Possedez vous un micro onde ?
   par défaut: oui
 divers . micro onde . durée:
-  question: Quel âge a votre micro onde ? 
+  formule: 8
   unité: ans
-  par défaut: 4 ans
 divers . micro onde:
   applicable si: présent
-  icônes: 
-  formule: 98.4 / (durée + 1)
+  icônes: 🥧
+  formule: 98.4 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
 divers . plaques . présent:
   question: Possedez vous des plaques de cuisson ?
   par défaut: oui
 divers . plaques . durée:
-  question: Quel âge ont vos plaques de cuisson ? 
+  formule: 6.66
   unité: ans
-  par défaut: 4 ans
 divers . plaques:
   applicable si: présent
-  icônes: 
-  formule: 65.3 / (durée + 1)
+  icônes: ⚫
+  formule: 65.3 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
   note: On considère des plaques vitrocéramiques
 
 divers . bouilloire . présent:
   question: Possedez vous une bouilloire ?
   par défaut: oui
 divers . bouilloire . durée:
-  question: Quel âge a votre bouilloire ? 
+  formule: 4
   unité: ans
-  par défaut: 4 ans
 divers . bouilloire:
   applicable si: présent
-  icônes: 
-  formule: 9.9 / (durée + 1)
+  icônes: 💧♨️
+  formule: 9.9 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
   
  divers . cafetière . présent:
   question: Possedez vous une cafetière ?
   par défaut: oui
 divers . cafetière . durée:
-  question: Quel âge a votre cafetière ? 
+  formule: 4
   unité: ans
-  par défaut: 4 ans
 divers . cafetière:
   applicable si: présent
-  icônes: 
-  formule: 31.9 / (durée + 1)
+  icônes: ☕
+  formule: 31.9 / (durée * coefficent préservation)
   unité: kgCO2e
-  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
   note: On considère une machine à filtre
+  
+ divers . aspirateur . présent:
+  question: Possedez vous un aspirateur ?
+  par défaut: oui
+divers . cafetière . durée:
+  formule: 5.33
+  unité: ans
+divers . cafetière:
+  applicable si: présent
+  icônes: 💨
+  formule: 52.4 / (durée * coefficent préservation)
+  unité: kgCO2e
+  note: On considère un aspirateur sans sac
+
+divers . électroménager . préservation:
+  question: Réparez-vous vos appareils lorsqu'il tombe en panne et faites vous en sorte de les faire durer le plus longtemps posible?
+  # Faites-vous en sorte d'allonger la durée de vie de vos appareils en les réparant lorsqu'ils tombent en panne ?
+  par défaut: "'non'"
+  formule:
+    une possibilité: 
+      choix obligatoire: oui
+      possibilités: 
+        - non
+        - en partie
+        - oui
+        
+divers . électroménager coefficient préservation: 
+  formule: 
+    variations: 
+        - si: préservation = 'non'
+          alors: 1
+        - si: préservation = 'en partie'
+          alors: 1.5
+        - sinon: 2
 
 intensité électricité: 
   titre: Intensité climat du mix électrique français

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -43,20 +43,20 @@ divers . autres produits . montant:
 divers . électroménager: 
   icônes: ⚙️🏠
   formule:
-      somme:
-      - réfrigérateur
-      - mini réfrigérateur
-      - lave-linge
-      - sèche-linge
-      - lave-vaisselle
-      - four
-      - micro-ondes
-      - plaques
-      - bouilloire
-      - cafetière
-      - aspirateur
-      - robot cuisine
-      - tondeuse électrique
+    somme:
+    - réfrigérateur
+    - mini réfrigérateur
+    - lave-linge
+    - sèche-linge
+    - lave-vaisselle
+    - four
+    - micro-ondes
+    - plaques
+    - bouilloire
+    - cafetière
+    - aspirateur
+    - robot cuisine
+    - tondeuse électrique
  
 
 divers . réfrigérateur . présent:
@@ -71,7 +71,7 @@ divers . réfrigérateur . durée:
 divers . réfrigérateur:
   applicable si: présent
   icônes: 🍅🥒
-  formule: 257 / (durée * coefficent préservation)
+  formule: 257 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . mini réfrigérateur . présent:
@@ -83,7 +83,7 @@ divers . mini réfrigérateur . durée:
 divers . mini réfrigérateur:
   applicable si: présent
   icônes: 🥒
-  formule: 87.6 / (durée * coefficent préservation)
+  formule: 87.6 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . lave-linge . présent:
@@ -95,7 +95,7 @@ divers . lave-linge . durée:
 divers . lave-linge:
   applicable si: présent
   icônes: 👕💧
-  formule: 342 / (durée * coefficent préservation)
+  formule: 342 / (durée * coefficient préservation)
   unité: kgCO2e
   
 divers . sèche-linge . présent:
@@ -107,7 +107,7 @@ divers . sèche-linge . durée:
 divers . sèche-linge:
   applicable si: présent
   icônes: 👕♨️
-  formule: 266 / (durée * coefficent préservation)
+  formule: 266 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . lave-vaisselle . présent:
@@ -119,7 +119,7 @@ divers . lave-vaisselle . durée:
 divers . lave-vaisselle:
   applicable si: présent
   icônes: 🍽️
-  formule: 271 / (durée * coefficent préservation)
+  formule: 271 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . four . présent:
@@ -131,7 +131,7 @@ divers . four . durée:
 divers . four:
   applicable si: présent
   icônes: 🍕
-  formule: 217 / (durée * coefficent préservation)
+  formule: 217 / (durée * coefficient préservation)
   unité: kgCO2e
   
 divers . micro-ondes . présent:
@@ -143,7 +143,7 @@ divers . micro-ondes . durée:
 divers . micro-ondes:
   applicable si: présent
   icônes: 🥧
-  formule: 98.4 / (durée * coefficent préservation)
+  formule: 98.4 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . plaques . présent:
@@ -155,7 +155,7 @@ divers . plaques . durée:
 divers . plaques:
   applicable si: présent
   icônes: ⚫
-  formule: 65.3 / (durée * coefficent préservation)
+  formule: 65.3 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère des plaques vitrocéramiques
 
@@ -168,10 +168,10 @@ divers . bouilloire . durée:
 divers . bouilloire:
   applicable si: présent
   icônes: 💧♨️
-  formule: 9.9 / (durée * coefficent préservation)
+  formule: 9.9 / (durée * coefficient préservation)
   unité: kgCO2e
   
- divers . cafetière . présent:
+divers . cafetière . présent:
   question: Possedez vous une cafetière ?
   par défaut: oui
 divers . cafetière . durée:
@@ -180,11 +180,11 @@ divers . cafetière . durée:
 divers . cafetière:
   applicable si: présent
   icônes: ☕
-  formule: 31.9 / (durée * coefficent préservation)
+  formule: 31.9 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère une machine à filtre
   
- divers . aspirateur . présent:
+divers . aspirateur . présent:
   question: Possedez vous un aspirateur ?
   par défaut: oui
 divers . aspirateur . durée:
@@ -193,11 +193,11 @@ divers . aspirateur . durée:
 divers . aspirateur:
   applicable si: présent
   icônes: 💨
-  formule: 52.4 / (durée * coefficent préservation)
+  formule: 52.4 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère un aspirateur sans sac
 
- divers . robot cuisine . présent:
+divers . robot cuisine . présent:
   question: Possedez vous un robot cuisine ?
   par défaut: non
 divers . robot cuisine . durée:
@@ -207,23 +207,24 @@ divers . robot cuisine . durée:
 divers . robot cuisine:
   applicable si: présent
   icônes: ☕
-  formule: 41.3/ (durée * coefficent préservation)
+  formule: 41.3 / (durée * coefficient préservation)
   unité: kgCO2e
   
- divers . tondeuse électrique . présent:
+divers . tondeuse électrique . présent:
   question: Possedez vous une tondeuse électrique ?
   par défaut: non
 divers . tondeuse électrique . durée:
   formule: 6.66
   unité: ans
-  note: Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
+  note: |
+    Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
 divers . tondeuse électrique:
   applicable si: présent
   icônes: 💨
-  formule: 70.1 / (durée * coefficent préservation)
+  formule: 70.1 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . électroménager . préservation:
+divers . préservation:
   question: Faites-vous en sorte d'allonger la durée de vie de vos appareils en les utilisant de manière adéquate et en les réparant lorsqu'ils tombent en panne ?
   par défaut: "'non'"
   formule:
@@ -233,8 +234,12 @@ divers . électroménager . préservation:
         - non
         - en partie
         - oui
+
+divers . préservation . non:
+divers . préservation . en partie:
+divers . préservation . oui:
         
-divers . électroménager coefficient préservation: 
+divers . coefficient préservation: 
   formule: 
     variations: 
         - si: préservation = 'non'

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -236,7 +236,7 @@ divers . électroménager . préservation:
   description: |
     Pour éviter de vous demander de renseigner l'âge précis de la dizaine d'appareils électroménager que vous possédez, nous utilisons une grille d'âge moyen constaté pour chaque appareil. 
 
-    Par exemple, un frigo dure en moyenne 10 ans, une bouilloire dure 6 ans. 
+    Par exemple, un frigo dure en moyenne 10 ans, un four 12 ans et une bouilloire 6 ans. Vous pouvez explorer la durée moyenne et l'empreinte de chaque appareil [ici](http://localhost:8080/documentation/divers/électroménager/appareils).
 
     > Il ne s'agit pas de l'âge de l'appareil quand il claque, mais de son âge quand son propriétaire décide de le remplacer par du neuf.
 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -62,7 +62,7 @@ divers . réfrigérateur . durée:
   unité: ans
   note: |
     Les durées de vies des appareils sont calculées de manière à ce que leur multiplication par le coefficient associé à la réponse "en partie" (1.5) recoupe avec
-    [ADEME](https://www.ademe.fr/evaluation-environnementale-economique-lallongement-duree-dusage-biens-dequipements-electriques-electroniques-a-lechelle-dun-foyer) Tableau 1 page 11
+    [ADEME](https://www.ademe.fr/evaluation-environnementale-economique-lallongement-duree-dusage-biens-dequipements-electriques-electroniques-a-lechelle-dun-foyer) Tableau 2 page 11
 divers . réfrigérateur:
   applicable si: présent
   icônes: 🍅🥒

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -220,29 +220,29 @@ divers . électroménager . tondeuse électrique . durée:
     Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
 divers . électroménager . tondeuse électrique:
   applicable si: présent
-  icônes: 💨
+  icônes: 🌱✂️
   formule: 70.1 / (durée * coefficient préservation)
   unité: kgCO2e
 
 divers . électroménager . préservation:
-  question: Faites-vous en sorte d'allonger la durée de vie de vos appareils en les utilisant de manière adéquate et en les réparant lorsqu'ils tombent en panne ?
-  par défaut: "'non'"
+  question: Quel effort faites-vous en pour garder vos appareils le plus longtemps possible ?
+  par défaut: "'presque pas'"
   formule:
     une possibilité: 
       choix obligatoire: oui
       possibilités: 
-        - non
+        - presque pas
         - en partie
-        - oui
+        - maximum
 
-divers . électroménager . préservation . non:
+divers . électroménager . préservation . presque pas:
 divers . électroménager . préservation . en partie:
-divers . électroménager . préservation . oui:
+divers . électroménager . préservation . maximum:
         
 divers . électroménager . coefficient préservation: 
   formule:
     variations: 
-        - si: préservation = 'non'
+        - si: préservation = 'presque pas'
           alors: 1
         - si: préservation = 'en partie'
           alors: 1.5

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -225,7 +225,7 @@ divers . électroménager . tondeuse électrique:
   unité: kgCO2e
 
 divers . électroménager . préservation:
-  question: Quel effort faites-vous en pour garder vos appareils le plus longtemps possible ?
+  question: Quel effort faites-vous en pour garder vos appareils électroménagers le plus longtemps possible ?
   par défaut: "'presque pas'"
   formule:
     une possibilité: 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -95,7 +95,7 @@ divers . électroménager . lave-linge . durée:
   unité: ans
 divers . électroménager . lave-linge:
   applicable si: présent
-  icônes: 👕💧
+  icônes: 💧👕
   formule: 342 / (durée * coefficient préservation)
   unité: kgCO2e
   
@@ -107,7 +107,7 @@ divers . électroménager . sèche-linge . durée:
   unité: ans
 divers . électroménager . sèche-linge:
   applicable si: présent
-  icônes: 👕♨️
+  icônes: 💨👕
   formule: 266 / (durée * coefficient préservation)
   unité: kgCO2e
 
@@ -168,7 +168,7 @@ divers . électroménager . bouilloire . durée:
   unité: ans
 divers . électroménager . bouilloire:
   applicable si: présent
-  icônes: 💧♨️
+  icônes: ♨️💧
   formule: 9.9 / (durée * coefficient préservation)
   unité: kgCO2e
   
@@ -207,7 +207,7 @@ divers . électroménager . robot cuisine . durée:
   note: aucune durée de vie n'est donnée dans les sources ADEME, nous considérons donc une durée de vie totale de 6 ans
 divers . électroménager . robot cuisine:
   applicable si: présent
-  icônes: ☕
+  icônes: 🤖🥣
   formule: 41.3 / (durée * coefficient préservation)
   unité: kgCO2e
   

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -59,172 +59,172 @@ divers . électroménager:
     - tondeuse électrique
  
 
-divers . réfrigérateur . présent:
+divers . électroménager . réfrigérateur . présent:
   question: Possedez vous un réfrigérateur ?
   par défaut: oui  
-divers . réfrigérateur . durée:
+divers . électroménager . réfrigérateur . durée:
   formule: 6.66
   unité: ans
   note: |
     Les durées de vies des appareils sont calculées de manière à ce que leur multiplication par le coefficient associé à la réponse "en partie" (1.5) recoupe avec
     [ADEME](https://www.ademe.fr/evaluation-environnementale-economique-lallongement-duree-dusage-biens-dequipements-electriques-electroniques-a-lechelle-dun-foyer) Tableau 2 page 11
-divers . réfrigérateur:
+divers . électroménager . réfrigérateur:
   applicable si: présent
   icônes: 🍅🥒
   formule: 257 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . mini réfrigérateur . présent:
+divers . électroménager . mini réfrigérateur . présent:
   question: Possedez vous un mini réfrigérateur ?
   par défaut: oui
-divers . mini réfrigérateur . durée:
+divers . électroménager . mini réfrigérateur . durée:
   formule: 6.66
   unité: ans
-divers . mini réfrigérateur:
+divers . électroménager . mini réfrigérateur:
   applicable si: présent
   icônes: 🥒
   formule: 87.6 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . lave-linge . présent:
+divers . électroménager . lave-linge . présent:
   question: Possedez vous un lave-linge ?
   par défaut: oui
-divers . lave-linge . durée:
+divers . électroménager . lave-linge . durée:
   formule: 6.66
   unité: ans
-divers . lave-linge:
+divers . électroménager . lave-linge:
   applicable si: présent
   icônes: 👕💧
   formule: 342 / (durée * coefficient préservation)
   unité: kgCO2e
   
-divers . sèche-linge . présent:
+divers . électroménager . sèche-linge . présent:
   question: Possedez vous un sèche-linge ?
   par défaut: oui
-divers . sèche-linge . durée:
+divers . électroménager . sèche-linge . durée:
   formule: 6.66
   unité: ans
-divers . sèche-linge:
+divers . électroménager . sèche-linge:
   applicable si: présent
   icônes: 👕♨️
   formule: 266 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . lave-vaisselle . présent:
+divers . électroménager . lave-vaisselle . présent:
   question: Possedez vous un lave-vaisselle ?
   par défaut: oui
-divers . lave-vaisselle . durée:
+divers . électroménager . lave-vaisselle . durée:
   formule: 6.66
   unité: ans
-divers . lave-vaisselle:
+divers . électroménager . lave-vaisselle:
   applicable si: présent
   icônes: 🍽️
   formule: 271 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . four . présent:
+divers . électroménager . four . présent:
   question: Possedez vous un four ?
   par défaut: oui
-divers . four . durée:
+divers . électroménager . four . durée:
   formule: 8
   unité: ans
-divers . four:
+divers . électroménager . four:
   applicable si: présent
   icônes: 🍕
   formule: 217 / (durée * coefficient préservation)
   unité: kgCO2e
   
-divers . micro-ondes . présent:
+divers . électroménager . micro-ondes . présent:
   question: Possedez vous un micro-ondes ?
   par défaut: oui
-divers . micro-ondes . durée:
+divers . électroménager . micro-ondes . durée:
   formule: 8
   unité: ans
-divers . micro-ondes:
+divers . électroménager . micro-ondes:
   applicable si: présent
   icônes: 🥧
   formule: 98.4 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . plaques . présent:
+divers . électroménager . plaques . présent:
   question: Possedez vous des plaques de cuisson ?
   par défaut: oui
-divers . plaques . durée:
+divers . électroménager . plaques . durée:
   formule: 6.66
   unité: ans
-divers . plaques:
+divers . électroménager . plaques:
   applicable si: présent
   icônes: ⚫
   formule: 65.3 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère des plaques vitrocéramiques
 
-divers . bouilloire . présent:
+divers . électroménager . bouilloire . présent:
   question: Possedez vous une bouilloire ?
   par défaut: oui
-divers . bouilloire . durée:
+divers . électroménager . bouilloire . durée:
   formule: 4
   unité: ans
-divers . bouilloire:
+divers . électroménager . bouilloire:
   applicable si: présent
   icônes: 💧♨️
   formule: 9.9 / (durée * coefficient préservation)
   unité: kgCO2e
   
-divers . cafetière . présent:
+divers . électroménager . cafetière . présent:
   question: Possedez vous une cafetière ?
   par défaut: oui
-divers . cafetière . durée:
+divers . électroménager . cafetière . durée:
   formule: 4
   unité: ans
-divers . cafetière:
+divers . électroménager . cafetière:
   applicable si: présent
   icônes: ☕
   formule: 31.9 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère une machine à filtre
   
-divers . aspirateur . présent:
+divers . électroménager . aspirateur . présent:
   question: Possedez vous un aspirateur ?
   par défaut: oui
-divers . aspirateur . durée:
+divers . électroménager . aspirateur . durée:
   formule: 5.33
   unité: ans
-divers . aspirateur:
+divers . électroménager . aspirateur:
   applicable si: présent
   icônes: 💨
   formule: 52.4 / (durée * coefficient préservation)
   unité: kgCO2e
   note: On considère un aspirateur sans sac
 
-divers . robot cuisine . présent:
+divers . électroménager . robot cuisine . présent:
   question: Possedez vous un robot cuisine ?
   par défaut: non
-divers . robot cuisine . durée:
+divers . électroménager . robot cuisine . durée:
   formule: 4
   unité: ans
   note: aucune durée de vie n'est donnée dans les sources ADEME, nous considérons donc une durée de vie totale de 6 ans
-divers . robot cuisine:
+divers . électroménager . robot cuisine:
   applicable si: présent
   icônes: ☕
   formule: 41.3 / (durée * coefficient préservation)
   unité: kgCO2e
   
-divers . tondeuse électrique . présent:
+divers . électroménager . tondeuse électrique . présent:
   question: Possedez vous une tondeuse électrique ?
   par défaut: non
-divers . tondeuse électrique . durée:
+divers . électroménager . tondeuse électrique . durée:
   formule: 6.66
   unité: ans
   note: |
     Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
-divers . tondeuse électrique:
+divers . électroménager . tondeuse électrique:
   applicable si: présent
   icônes: 💨
   formule: 70.1 / (durée * coefficient préservation)
   unité: kgCO2e
 
-divers . préservation:
+divers . électroménager . préservation:
   question: Faites-vous en sorte d'allonger la durée de vie de vos appareils en les utilisant de manière adéquate et en les réparant lorsqu'ils tombent en panne ?
   par défaut: "'non'"
   formule:
@@ -235,12 +235,12 @@ divers . préservation:
         - en partie
         - oui
 
-divers . préservation . non:
-divers . préservation . en partie:
-divers . préservation . oui:
+divers . électroménager . préservation . non:
+divers . électroménager . préservation . en partie:
+divers . électroménager . préservation . oui:
         
-divers . coefficient préservation: 
-  formule: 
+divers . électroménager . coefficient préservation: 
+  formule:
     variations: 
         - si: préservation = 'non'
           alors: 1

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -4,19 +4,7 @@ divers:
   formule: 
     somme:
       - textile
-      - réfrigérateur
-      - mini réfrigérateur
-      - lave linge
-      - sèche linge
-      - lave vaiselle
-      - four
-      - micro onde
-      - plaques
-      - bouilloire
-      - cafetière
-      - aspirateur
-      - robot cuisine
-      - tondeuse électrique
+      - électroménager
       - autres produits
 
 
@@ -31,21 +19,6 @@ divers . textile . montant:
   source: Base Carbone, ratio monétaire (textile et habillement 600 kgCO2e / k€ HT) ; https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Ratio-monetaires
   unité: €/an
   par défaut: 1000 €/an
-
-
-
-divers . électroménager: 
-  icônes: 👗
-  formule: 1 * montant  
-  unité: kgCO2e
-
-divers . électroménager . montant: 
-  question: Combien dépensez-vous par an en électroménager acheté neuf ? 
-  description: Nous excluons du calcul la récupération et l'occasion.
-  unité: €/an
-  par défaut: 1200 €/an
-
-
 
 divers . autres produits: 
   icônes: 👗
@@ -65,7 +38,26 @@ divers . autres produits . montant:
   note: Cette catégorie est assez vague, il faudrait au moins donner plus d'exemples.
   par défaut: 2000 €/an
   
-  
+
+
+divers . électroménager: 
+  formule:
+      somme:
+      - réfrigérateur
+      - mini réfrigérateur
+      - lave linge
+      - sèche linge
+      - lave vaiselle
+      - four
+      - micro onde
+      - plaques
+      - bouilloire
+      - cafetière
+      - aspirateur
+      - robot cuisine
+      - tondeuse électrique
+ 
+
 divers . réfrigérateur . présent:
   question: Possedez vous un réfrigérateur ?
   par défaut: oui  

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -54,7 +54,147 @@ divers . autres produits . montant:
   par défaut: 2000 €/an
 
 
+divers . réfrigérateur . présent:
+  question: Possedez vous un réfrigérateur ?
+  par défaut: oui
+divers . réfrigérateur . durée:
+  question: Quel âge a votre réfrigérateur ? 
+  unité: ans
+  par défaut: 4 ans
+divers . réfrigérateur:
+  applicable si: présent
+  icônes: 
+  formule: 257 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
 
+divers . mini réfrigérateur . présent:
+  question: Possedez vous un mini réfrigérateur ?
+  par défaut: oui
+divers . mini réfrigérateur . durée:
+  question: Quel âge a votre mini réfrigérateur ? 
+  unité: ans
+  par défaut: 4 ans
+divers . mini réfrigérateur:
+  applicable si: présent
+  icônes: 
+  formule: 87.6 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+
+divers . lave linge . présent:
+  question: Possedez vous un lave linge ?
+  par défaut: oui
+divers . lave linge . durée:
+  question: Quel âge a votre lave linge ? 
+  unité: ans
+  par défaut: 4 ans
+divers . lave linge:
+  applicable si: présent
+  icônes: 
+  formule: 342 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+  
+divers . sèche linge . présent:
+  question: Possedez vous un sèche linge ?
+  par défaut: oui
+divers . sèche linge . durée:
+  question: Quel âge a votre sèche linge ? 
+  unité: ans
+  par défaut: 4 ans
+divers . sèche linge:
+  applicable si: présent
+  icônes: 
+  formule: 266 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+
+divers . lave vaiselle . présent:
+  question: Possedez vous un lave vaiselle ?
+  par défaut: oui
+divers . lave vaiselle . durée:
+  question: Quel âge a votre lave vaiselle ? 
+  unité: ans
+  par défaut: 4 ans
+divers . lave vaiselle:
+  applicable si: présent
+  icônes: 
+  formule: 271 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+
+divers . four . présent:
+  question: Possedez vous un four ?
+  par défaut: oui
+divers . four . durée:
+  question: Quel âge a votre four ? 
+  unité: ans
+  par défaut: 4 ans
+divers . four:
+  applicable si: présent
+  icônes: 
+  formule: 217 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+  
+divers . micro onde . présent:
+  question: Possedez vous un micro onde ?
+  par défaut: oui
+divers . micro onde . durée:
+  question: Quel âge a votre micro onde ? 
+  unité: ans
+  par défaut: 4 ans
+divers . micro onde:
+  applicable si: présent
+  icônes: 
+  formule: 98.4 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+
+divers . plaques . présent:
+  question: Possedez vous des plaques de cuisson ?
+  par défaut: oui
+divers . plaques . durée:
+  question: Quel âge ont vos plaques de cuisson ? 
+  unité: ans
+  par défaut: 4 ans
+divers . plaques:
+  applicable si: présent
+  icônes: 
+  formule: 65.3 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+  note: On considère des plaques vitrocéramiques
+
+divers . bouilloire . présent:
+  question: Possedez vous une bouilloire ?
+  par défaut: oui
+divers . bouilloire . durée:
+  question: Quel âge a votre bouilloire ? 
+  unité: ans
+  par défaut: 4 ans
+divers . bouilloire:
+  applicable si: présent
+  icônes: 
+  formule: 9.9 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+  
+ divers . cafetière . présent:
+  question: Possedez vous une cafetière ?
+  par défaut: oui
+divers . cafetière . durée:
+  question: Quel âge a votre cafetière ? 
+  unité: ans
+  par défaut: 4 ans
+divers . cafetière:
+  applicable si: présent
+  icônes: 
+  formule: 31.9 / (durée + 1)
+  unité: kgCO2e
+  note: Nous estimons que l'appareil va durer un an de plus que l'âge renseigné au moment de l'estimation.
+  note: On considère une machine à filtre
 
 intensité électricité: 
   titre: Intensité climat du mix électrique français

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -46,11 +46,11 @@ divers . électroménager:
       somme:
       - réfrigérateur
       - mini réfrigérateur
-      - lave linge
-      - sèche linge
-      - lave vaiselle
+      - lave-linge
+      - sèche-linge
+      - lave-vaisselle
       - four
-      - micro onde
+      - micro-ondes
       - plaques
       - bouilloire
       - cafetière
@@ -86,37 +86,37 @@ divers . mini réfrigérateur:
   formule: 87.6 / (durée * coefficent préservation)
   unité: kgCO2e
 
-divers . lave linge . présent:
-  question: Possedez vous un lave linge ?
+divers . lave-linge . présent:
+  question: Possedez vous un lave-linge ?
   par défaut: oui
-divers . lave linge . durée:
+divers . lave-linge . durée:
   formule: 6.66
   unité: ans
-divers . lave linge:
+divers . lave-linge:
   applicable si: présent
   icônes: 👕💧
   formule: 342 / (durée * coefficent préservation)
   unité: kgCO2e
   
-divers . sèche linge . présent:
-  question: Possedez vous un sèche linge ?
+divers . sèche-linge . présent:
+  question: Possedez vous un sèche-linge ?
   par défaut: oui
-divers . sèche linge . durée:
+divers . sèche-linge . durée:
   formule: 6.66
   unité: ans
-divers . sèche linge:
+divers . sèche-linge:
   applicable si: présent
   icônes: 👕♨️
   formule: 266 / (durée * coefficent préservation)
   unité: kgCO2e
 
-divers . lave vaiselle . présent:
-  question: Possedez vous un lave vaiselle ?
+divers . lave-vaisselle . présent:
+  question: Possedez vous un lave-vaisselle ?
   par défaut: oui
-divers . lave vaiselle . durée:
+divers . lave-vaisselle . durée:
   formule: 6.66
   unité: ans
-divers . lave vaiselle:
+divers . lave-vaisselle:
   applicable si: présent
   icônes: 🍽️
   formule: 271 / (durée * coefficent préservation)
@@ -134,13 +134,13 @@ divers . four:
   formule: 217 / (durée * coefficent préservation)
   unité: kgCO2e
   
-divers . micro onde . présent:
-  question: Possedez vous un micro onde ?
+divers . micro-ondes . présent:
+  question: Possedez vous un micro-ondes ?
   par défaut: oui
-divers . micro onde . durée:
+divers . micro-ondes . durée:
   formule: 8
   unité: ans
-divers . micro onde:
+divers . micro-ondes:
   applicable si: présent
   icônes: 🥧
   formule: 98.4 / (durée * coefficent préservation)

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -63,7 +63,7 @@ divers . électroménager . réfrigérateur . présent:
   question: Possedez vous un réfrigérateur ?
   par défaut: oui  
 divers . électroménager . réfrigérateur . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
   note: |
     Les durées de vies des appareils sont calculées de manière à ce que leur multiplication par le coefficient associé à la réponse "en partie" (1.5) recoupe avec
@@ -78,7 +78,7 @@ divers . électroménager . mini réfrigérateur . présent:
   question: Possedez vous un mini réfrigérateur ?
   par défaut: oui
 divers . électroménager . mini réfrigérateur . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
 divers . électroménager . mini réfrigérateur:
   applicable si: présent
@@ -90,7 +90,7 @@ divers . électroménager . lave-linge . présent:
   question: Possedez vous un lave-linge ?
   par défaut: oui
 divers . électroménager . lave-linge . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
 divers . électroménager . lave-linge:
   applicable si: présent
@@ -102,7 +102,7 @@ divers . électroménager . sèche-linge . présent:
   question: Possedez vous un sèche-linge ?
   par défaut: oui
 divers . électroménager . sèche-linge . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
 divers . électroménager . sèche-linge:
   applicable si: présent
@@ -114,7 +114,7 @@ divers . électroménager . lave-vaisselle . présent:
   question: Possedez vous un lave-vaisselle ?
   par défaut: oui
 divers . électroménager . lave-vaisselle . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
 divers . électroménager . lave-vaisselle:
   applicable si: présent
@@ -126,7 +126,7 @@ divers . électroménager . four . présent:
   question: Possedez vous un four ?
   par défaut: oui
 divers . électroménager . four . durée:
-  formule: 8
+  formule: 12
   unité: ans
 divers . électroménager . four:
   applicable si: présent
@@ -138,7 +138,7 @@ divers . électroménager . micro-ondes . présent:
   question: Possedez vous un micro-ondes ?
   par défaut: oui
 divers . électroménager . micro-ondes . durée:
-  formule: 8
+  formule: 12
   unité: ans
 divers . électroménager . micro-ondes:
   applicable si: présent
@@ -150,7 +150,7 @@ divers . électroménager . plaques . présent:
   question: Possedez vous des plaques de cuisson ?
   par défaut: oui
 divers . électroménager . plaques . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
 divers . électroménager . plaques:
   applicable si: présent
@@ -163,7 +163,7 @@ divers . électroménager . bouilloire . présent:
   question: Possedez vous une bouilloire ?
   par défaut: oui
 divers . électroménager . bouilloire . durée:
-  formule: 4
+  formule: 6
   unité: ans
 divers . électroménager . bouilloire:
   applicable si: présent
@@ -175,7 +175,7 @@ divers . électroménager . cafetière . présent:
   question: Possedez vous une cafetière ?
   par défaut: oui
 divers . électroménager . cafetière . durée:
-  formule: 4
+  formule: 6
   unité: ans
 divers . électroménager . cafetière:
   applicable si: présent
@@ -188,7 +188,7 @@ divers . électroménager . aspirateur . présent:
   question: Possedez vous un aspirateur ?
   par défaut: oui
 divers . électroménager . aspirateur . durée:
-  formule: 5.33
+  formule: 8
   unité: ans
 divers . électroménager . aspirateur:
   applicable si: présent
@@ -201,7 +201,7 @@ divers . électroménager . robot cuisine . présent:
   question: Possedez vous un robot cuisine ?
   par défaut: non
 divers . électroménager . robot cuisine . durée:
-  formule: 4
+  formule: 6
   unité: ans
   note: aucune durée de vie n'est donnée dans les sources ADEME, nous considérons donc une durée de vie totale de 6 ans
 divers . électroménager . robot cuisine:
@@ -214,7 +214,7 @@ divers . électroménager . tondeuse électrique . présent:
   question: Possedez vous une tondeuse électrique ?
   par défaut: non
 divers . électroménager . tondeuse électrique . durée:
-  formule: 6.66
+  formule: 10
   unité: ans
   note: |
     Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
@@ -243,10 +243,10 @@ divers . électroménager . coefficient préservation:
   formule:
     variations: 
         - si: préservation = 'presque pas'
-          alors: 1
+          alors: 2 / 3
         - si: préservation = 'en partie'
-          alors: 1.5
-        - sinon: 2
+          alors: 1
+        - sinon: 4 / 3
 
 intensité électricité: 
   titre: Intensité climat du mix électrique français

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -4,7 +4,19 @@ divers:
   formule: 
     somme:
       - textile
-      - électroménager
+      - réfrigérateur
+      - mini réfrigérateur
+      - lave linge
+      - sèche linge
+      - lave vaiselle
+      - four
+      - micro onde
+      - plaques
+      - bouilloire
+      - cafetière
+      - aspirateur
+      - robot cuisine
+      - tondeuse électrique
       - autres produits
 
 
@@ -191,6 +203,32 @@ divers . aspirateur:
   formule: 52.4 / (durée * coefficent préservation)
   unité: kgCO2e
   note: On considère un aspirateur sans sac
+
+ divers . robot cuisine . présent:
+  question: Possedez vous un robot cuisine ?
+  par défaut: non
+divers . robot cuisine . durée:
+  formule: 4
+  unité: ans
+  note: aucune durée de vie n'est donnée dans les sources ADEME, nous considérons donc une durée de vie totale de 6 ans
+divers . robot cuisine:
+  applicable si: présent
+  icônes: ☕
+  formule: 41.3/ (durée * coefficent préservation)
+  unité: kgCO2e
+  
+ divers . tondeuse électrique . présent:
+  question: Possedez vous une tondeuse électrique ?
+  par défaut: non
+divers . tondeuse électrique . durée:
+  formule: 6.66
+  unité: ans
+  note: Source : Modélisation et évaluation environnementale de produits de consommation et biens d'équipement - Tab. 4.5 - Ademe
+divers . tondeuse électrique:
+  applicable si: présent
+  icônes: 💨
+  formule: 70.1 / (durée * coefficent préservation)
+  unité: kgCO2e
 
 divers . électroménager . préservation:
   question: Faites-vous en sorte d'allonger la durée de vie de vos appareils en les utilisant de manière adéquate et en les réparant lorsqu'ils tombent en panne ?

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -233,6 +233,14 @@ divers . électroménager . tondeuse électrique:
 
 divers . électroménager . préservation:
   question: Quel effort faites-vous en pour garder vos appareils électroménagers le plus longtemps possible ?
+  description: |
+    Pour éviter de vous demander de renseigner l'âge précis de la dizaine d'appareils électroménager que vous possédez, nous utilisons une grille d'âge moyen constaté pour chaque appareil. 
+
+    Par exemple, un frigo dure en moyenne 10 ans, une bouilloire dure 6 ans. 
+
+    > Il ne s'agit pas de l'âge de l'appareil quand il claque, mais de son âge quand son propriétaire décide de le remplacer par du neuf.
+
+    A vous de vous placer par rapport à la moyenne. 
   par défaut: "'moyen'"
   formule:
     une possibilité: 

--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -21,7 +21,7 @@ divers . textile . montant:
   par défaut: 1000 €/an
 
 divers . autres produits: 
-  icônes: 👗
+  icônes: 📦
   formule: 0.055 * montant  
   unité: kgCO2e
 
@@ -41,6 +41,7 @@ divers . autres produits . montant:
 
 
 divers . électroménager: 
+  icônes: ⚙️🏠
   formule:
       somme:
       - réfrigérateur


### PR DESCRIPTION
1er jet pour lister les différents bien électroménager d'un individu. L'idéal serait d'avoir la même forme que pour le listing des biens d'équipements électroniques (case à cocher)

Connaitre le détail des biens permettra d'affiner l'estimation carbone du poste divers et permettra de créer certaines actions (allongement durée de vie, séchage air libre, etc.)


