### PR TITLE
Question baisse 1°

### DIFF
--- a/data/actions/logement.yaml
+++ b/data/actions/logement.yaml
@@ -25,7 +25,7 @@ logement . empreinte chauffage:
     somme: 
       - électricité * part chauffage . électricité
       - gaz * part chauffage . gaz
-      - bois * part chauffage . bois
+      - bois * part chauffage . bois 
       - fioul * part chauffage . fioul
   note: |
     Ici, nous proposons ce calcul simplifié. Il est assez théorique, car on peut chauffer son logement au bois, tout en ayant une consommation d'électricité sans chauffage. C'est une 1ère estimation.


### PR DESCRIPTION
Ne devrait-on pas en 1ère approximation ne pas faire la somme des différentes réductions calculées pour chaque mode de chauffage car il très rare d'avoir deux modes de chauffages.

Ce qui est fait
> "logement . empreinte chauffage:
  formule:
    somme: 
      - électricité * part chauffage . électricité
      - gaz * part chauffage . gaz
      - bois * part chauffage . bois
      - fioul * part chauffage . fioul"

Par ce calcul, on majore donc dans le cas de chauffage bois, gaz, fioul la portée de la réduction en y ajoutant une réduction de 7% de la conso d'électricité.
