### PR TITLE
Correction remplacer fioul par bois

### DIFF
--- a/data/actions/logement.yaml
+++ b/data/actions/logement.yaml
@@ -106,7 +106,6 @@ logement . remplacer fioul par bois:
 logement . remplacer fioul par bois . alternative: 
   formule: fioul . consommation * bois . facteur d'émission . granulés
 
- 
 logement . climatisation:
 
 logement . climatisation . réduction:


### PR DESCRIPTION
Lorsque que l'utilisateur répond aux questions pour affiner l'action il doit répondre à la question suivante qui ne sert à rien.  Le calcul considère bien des granulés mais je ne sais pas pourquoi la question est posée

![image](https://user-images.githubusercontent.com/66410914/114420859-01695c00-9bb5-11eb-9331-94f677ca0c16.png)
