### PR TITLE
action allonger durée vie électroménager

### DIFF
--- a/data/actions/divers.yaml
+++ b/data/actions/divers.yaml
@@ -27,19 +27,16 @@ divers . publicité:
   inactive: oui
 
 divers . électroménager . allongement:
-  titre: Allonger la durée de mon électroménager
+  titre: Allonger la durée de vie de mon électroménager
   non applicable si: préservation = 'oui'
   icônes: 💪🔌 
   effort: modéré
+  formule: électroménager - électroménager . préservé
   description: |
     Augmenter la durée de vie de ses équipements électroménager (en en prenant soin ou en les réparant lorsqu'ils tombent en panne) permet de limiter son impact
     sur le climat. Renouveler de manière prématurée ses équipements, à l'inverse, c'est contribuer à produire plus d'équipements pour un même service rendu. 
     Et produire ces équipements n'est pas sans impact, bien au contraire !
   # Description à retravailler 
-  formule: électroménager - électroménager . préservé
-
-divers . électroménager:
-  formule: réfrigérateur + mini réfrigérateur + lave linge + sèche linge + lave vaiselle + four + micro onde + plaques + bouilloire + cafetière + aspirateur
 
 divers . électroménager . préservé:
   formule: réfrigérateur . préservé + mini réfrigérateur . préservé + lave linge . préservé + sèche linge . préservé + lave vaiselle . préservé + four . préservé + micro onde . préservé + plaques . préservé + bouilloire . préservé + cafetière . préservé + aspirateur . préservé 

--- a/data/actions/divers.yaml
+++ b/data/actions/divers.yaml
@@ -42,8 +42,63 @@ divers . électroménager:
   formule: réfrigérateur + mini réfrigérateur + lave linge + sèche linge + lave vaiselle + four + micro onde + plaques + bouilloire + cafetière + aspirateur
 
 divers . électroménager . préservé:
-  formule: (257 / (durée * 2)) + (87.6 / (durée * 2)) + (342 / (durée * 2)) + (266  / (durée * 2)) + (271 / (durée * 2)) + (217 / (durée * 2)) + (98.4 / (durée * 2)) + (65.3 / (durée * 2)) + (9.9 / (durée * 2)) + (31.9 / (durée * 2)) + (5.33 / (durée * 2))
+  formule: réfrigérateur . préservé + mini réfrigérateur . préservé + lave linge . préservé + sèche linge . préservé + lave vaiselle . préservé + four . préservé + micro onde . préservé + plaques . préservé + bouilloire . préservé + cafetière . préservé + aspirateur . préservé 
 
+divers . réfrigérateur . préservé:
+  applicable si: réfrigérateur . présent
+  formule: 257  / (durée * 2)
+  unité: kgCO2e
+
+divers . mini réfrigérateur . préservé:
+  applicable si: mini réfrigérateur . présent
+  formule: 87.6  / (durée * 2)
+  unité: kgCO2e
+
+divers . lave linge . préservé:
+  applicable si: lave linge . présent
+  formule: 342  / (durée * 2)
+  unité: kgCO2e
+
+divers . sèche linge . préservé:
+  applicable si: sèche linge . présent
+  formule: 266  / (durée * 2)
+  unité: kgCO2e
+
+divers . lave vaisselle . préservé:
+  applicable si: lave vaisselle . présent
+  formule: 271  / (durée * 2)
+  unité: kgCO2e
+
+divers . four . préservé:
+  applicable si: four . présent
+  formule: 217  / (durée * 2)
+  unité: kgCO2e
+
+divers . micro onde . préservé:
+  applicable si: micro onde . présent
+  formule: 98.4  / (durée * 2)
+  unité: kgCO2e
+
+divers . plaques . préservé:
+  applicable si: plaques . présent
+  formule: 65.3  / (durée * 2)
+  unité: kgCO2e
+  
+divers . bouilloire . préservé:
+  applicable si: bouilloire . présent
+  formule: 9.9  / (durée * 2)
+  unité: kgCO2e
+
+divers . cafetière . préservé:
+  applicable si: cafetière . présent
+  formule: 31.9  / (durée * 2)
+  unité: kgCO2e
+  
+divers . aspirateur . préservé:
+  applicable si: aspirateur . présent
+  formule: 52.4  / (durée * 2)
+  unité: kgCO2e
+  
 divers . électroménager . seconde main:
   titre: Acheter d'occasion mon électroménager
   icônes: 🤝🔌

--- a/data/actions/divers.yaml
+++ b/data/actions/divers.yaml
@@ -27,9 +27,22 @@ divers . publicité:
   inactive: oui
 
 divers . électroménager . allongement:
-  titre: Faire durer mon électroménager
-  icônes: 💪🔌
-  inactive: oui
+  titre: Allonger la durée de mon électroménager
+  non applicable si: préservation = 'oui'
+  icônes: 💪🔌 
+  effort: modéré
+  description: |
+    Augmenter la durée de vie de ses équipements électroménager (en en prenant soin ou en les réparant lorsqu'ils tombent en panne) permet de limiter son impact
+    sur le climat. Renouveler de manière prématurée ses équipements, à l'inverse, c'est contribuer à produire plus d'équipements pour un même service rendu. 
+    Et produire ces équipements n'est pas sans impact, bien au contraire !
+  # Description à retravailler 
+  formule: électroménager - électroménager . préservé
+
+divers . électroménager:
+  formule: réfrigérateur + mini réfrigérateur + lave linge + sèche linge + lave vaiselle + four + micro onde + plaques + bouilloire + cafetière + aspirateur
+
+divers . électroménager . préservé:
+  formule: (257 / (durée * 2)) + (87.6 / (durée * 2)) + (342 / (durée * 2)) + (266  / (durée * 2)) + (271 / (durée * 2)) + (217 / (durée * 2)) + (98.4 / (durée * 2)) + (65.3 / (durée * 2)) + (9.9 / (durée * 2)) + (31.9 / (durée * 2)) + (5.33 / (durée * 2))
 
 divers . électroménager . seconde main:
   titre: Acheter d'occasion mon électroménager


### PR DESCRIPTION
Philosophie de l'action contestable d'un point de vue purement "comptabilité carbone" car il s'agit plutôt d'émissions évitées (au regard d'un non achat prématuré d'un nouvel équipement) et non d'émissions réduites.
En première approche on peut tout de même la considérer afin de sensibiliser à l'enjeu de "faire durée ces équipements et éviter les renouvellements prématurés"