### PR TITLE
Ajout question gaspillage alimentaire

### DIFF
--- a/data/actions.yaml
+++ b/data/actions.yaml
@@ -11,6 +11,7 @@ actions:
       - alimentation . manger de saison
       - alimentation . boisson . eau en bouteille . arrêter
       - alimentation . manger local
+      - alimentation . gaspillage alimentaire . réduire
       - logement . éteindre appareils
       - logement . remplacer fioul par bois
       - logement . remplacer gaz par PAC

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -167,7 +167,10 @@ alimentation . gaspillage alimentaire:
   références:
     - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
 
-alimentation . déchets . action:
+
+
+
+alimentation . déchets . action: 
   titre: Passer au zéro déchet
   icônes: 📦🚯
   inactive: oui
@@ -208,6 +211,30 @@ alimentation . boisson . eau en bouteille . arrêter:
     gestion des déchets plastiques dans les [explication complètes](https://nosgestesclimat.fr/actions/plus/alimentation/d%C3%A9chets/vrac)
 
     Sources : [Écobilan de l’eau potable](http://esu-services.ch/fileadmin/download/jungbluth-2015-ecobilan-eau.pdf) et [Ministère de la Transition Ecologique p106](https://www.economie.gouv.fr/files/files/directions_services/cge/filieres-dechets-recyclage.pdf)
+
+
+alimentation . gaspillage alimentaire:
+  inapplicable si: fréquence = 'jamais'
+  icônes: 🍲🚯
+  titre: Réduire mon gaspillage alimentaire
+  formule:
+    variations:
+      - si: fréquence = 'souvent'
+         alors: 31 #60 - 29
+       - si: fréquence = 'parfois'
+         alors: 16 #45 - 29
+  description: |
+    En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! Si l’on élargi l'échelle et que l'on considère
+    l’ensemble de la chaîne de valeur (c'est-à-dire du champ à l’assiette) c’est environ 10 millions de tonnes d'aliments qui sont gaspillées par an, soit 150 kg par habitant.
+    
+    Réduire le gaspillage alimentaire est donc essentiel afin d'éviter de produire pour jeter !
+    
+    Vous trouverez des conseils et des pratiques utiles [ici](https://agirpourlatransition.ademe.fr/particuliers/conso/alimentation/pourquoi-gaspillons-autant-nourriture)
+    
+  note: Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
+  références: 
+    - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
+
 
 alimentation . déchets . composter:
   titre: Composter

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -225,17 +225,11 @@ alimentation . gaspillage alimentaire:
        - si: fréquence = 'parfois'
          alors: 16 #45 - 29
   description: |
-    En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! Si l’on élargi l'échelle et que l'on considère
-    l’ensemble de la chaîne de valeur (c'est-à-dire du champ à l’assiette) c’est environ 10 millions de tonnes d'aliments qui sont gaspillées par an, soit 150 kg par habitant.
-    
+    En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! Si l’on prend du recule et que l'on considère l’ensemble de la chaîne de valeur (c'est-à-dire du champ à l’assiette) c’est environ 10 millions de tonnes d'aliments qui sont gaspillées par an, soit 150 kg par habitant.
+
     Réduire le gaspillage alimentaire est donc essentiel afin d'éviter de produire pour jeter !
-    
+
     Vous trouverez des conseils et des pratiques utiles [ici](https://agirpourlatransition.ademe.fr/particuliers/conso/alimentation/pourquoi-gaspillons-autant-nourriture)
-    
-  note: |
-    Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
-  références: 
-    - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
 
 
 alimentation . déchets . composter:

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -28,8 +28,8 @@ alimentation . réduire viande . par deux . par semaine . nouveau régime:
       - plats . poisson 2
       - compensation végétarienne
 
-alimentation . réduire viande . par deux . par semaine . nouveau régime . compensation végétarienne:
-  formule: plats . végétarien . empreinte * (nombre de plats viande / 2)
+? alimentation . réduire viande . par deux . par semaine . nouveau régime . compensation végétarienne
+: formule: plats . végétarien . empreinte * (nombre de plats viande / 2)
   description: On compense la division par 2 des plats de viande par des plats végétariens.
 
 alimentation . réduire viande . par quatre:
@@ -59,8 +59,8 @@ alimentation . réduire viande . par quatre . par semaine . nouveau régime:
       - plats . poisson 2
       - compensation végétarienne
 
-alimentation . réduire viande . par quatre . par semaine . nouveau régime . compensation végétarienne:
-  formule: plats . végétarien . empreinte * (nombre de plats viande * (3 / 4))
+? alimentation . réduire viande . par quatre . par semaine . nouveau régime . compensation végétarienne
+: formule: plats . végétarien . empreinte * (nombre de plats viande * (3 / 4))
   description: On compense la division par 4 des plats de viande par des plats végétariens.
 
 alimentation . devenir végétarien:
@@ -134,8 +134,8 @@ alimentation . viande faible empreinte . par semaine . nouveau régime:
       - plats . végétarien
       - compensation viande 1
 
-alimentation . viande faible empreinte . par semaine . nouveau régime . compensation viande 1:
-  formule: plats . viande 1 . empreinte * (plats . viande 2 . nombre)
+? alimentation . viande faible empreinte . par semaine . nouveau régime . compensation viande 1
+: formule: plats . viande 1 . empreinte * (plats . viande 2 . nombre)
   description: On compense la suppression des plat viande 2 en plat viande 1.
 
 alimentation . manger local:
@@ -167,10 +167,7 @@ alimentation . gaspillage alimentaire:
   références:
     - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
 
-
-
-
-alimentation . déchets . action: 
+alimentation . déchets . action:
   titre: Passer au zéro déchet
   icônes: 📦🚯
   inactive: oui
@@ -212,25 +209,32 @@ alimentation . boisson . eau en bouteille . arrêter:
 
     Sources : [Écobilan de l’eau potable](http://esu-services.ch/fileadmin/download/jungbluth-2015-ecobilan-eau.pdf) et [Ministère de la Transition Ecologique p106](https://www.economie.gouv.fr/files/files/directions_services/cge/filieres-dechets-recyclage.pdf)
 
-
-alimentation . gaspillage alimentaire:
-  inapplicable si: fréquence = 'jamais'
+alimentation . réduire gaspillage alimentaire:
+  non applicable si: fréquence = 'jamais'
   icônes: 🍲🚯
-  titre: Réduire mon gaspillage alimentaire
-  effort: modéré
+  titre: Moins gaspiller
   formule:
-    variations:
-      - si: fréquence = 'souvent'
-         alors: 31 #60 - 29
-       - si: fréquence = 'parfois'
-         alors: 16 #45 - 29
+    gaspillage alimentaire - réduction
+    #   variations:
+    # - si: fréquence = 'souvent'
+    #    alors: 31 #60 - 29
+    #  - si: fréquence = 'parfois'
+    #    alors: 16 #45 - 29
   description: |
-    En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! Si l’on prend du recule et que l'on considère l’ensemble de la chaîne de valeur (c'est-à-dire du champ à l’assiette) c’est environ 10 millions de tonnes d'aliments qui sont gaspillées par an, soit 150 kg par habitant.
+    En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! 
+
+    Si l’on prend du recule et que l'on considère l’ensemble de la chaîne de valeur (c'est-à-dire du champ à l’assiette) c’est environ 10 millions de tonnes d'aliments qui sont gaspillées par an, soit 150 kg par habitant.
 
     Réduire le gaspillage alimentaire est donc essentiel afin d'éviter de produire pour jeter !
 
     Vous trouverez des conseils et des pratiques utiles [ici](https://agirpourlatransition.ademe.fr/particuliers/conso/alimentation/pourquoi-gaspillons-autant-nourriture)
 
+alimentation . gaspillage alimentaire . réduit:
+  formule:
+    recalcul:
+      règle: alimentation . gaspillage alimentaire
+      avec:
+        fréquence: 'jamais'
 
 alimentation . déchets . composter:
   titre: Composter

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -209,12 +209,12 @@ alimentation . boisson . eau en bouteille . arrêter:
 
     Sources : [Écobilan de l’eau potable](http://esu-services.ch/fileadmin/download/jungbluth-2015-ecobilan-eau.pdf) et [Ministère de la Transition Ecologique p106](https://www.economie.gouv.fr/files/files/directions_services/cge/filieres-dechets-recyclage.pdf)
 
-alimentation . réduire gaspillage alimentaire:
+alimentation . gaspillage alimentaire . réduire:
   non applicable si: fréquence = 'jamais'
   icônes: 🍲🚯
   titre: Moins gaspiller
   formule:
-    gaspillage alimentaire - réduction
+    gaspillage alimentaire - réduit
     #   variations:
     # - si: fréquence = 'souvent'
     #    alors: 31 #60 - 29
@@ -234,7 +234,7 @@ alimentation . gaspillage alimentaire . réduit:
     recalcul:
       règle: alimentation . gaspillage alimentaire
       avec:
-        fréquence: 'jamais'
+        fréquence: "'jamais'"
 
 alimentation . déchets . composter:
   titre: Composter

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -213,13 +213,7 @@ alimentation . gaspillage alimentaire . réduire:
   non applicable si: fréquence = 'jamais'
   icônes: 🍲🚯
   titre: Moins gaspiller
-  formule:
-    gaspillage alimentaire - réduit
-    #   variations:
-    # - si: fréquence = 'souvent'
-    #    alors: 31 #60 - 29
-    #  - si: fréquence = 'parfois'
-    #    alors: 16 #45 - 29
+  formule: gaspillage alimentaire - réduit
   description: |
     En France le gaspillage alimentaire moyen est évalué à 32 kg par personne et par an dont 7 kg d’aliments encore emballés ! 
 

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -217,6 +217,7 @@ alimentation . gaspillage alimentaire:
   inapplicable si: fréquence = 'jamais'
   icônes: 🍲🚯
   titre: Réduire mon gaspillage alimentaire
+  effort: modéré
   formule:
     variations:
       - si: fréquence = 'souvent'
@@ -231,7 +232,8 @@ alimentation . gaspillage alimentaire:
     
     Vous trouverez des conseils et des pratiques utiles [ici](https://agirpourlatransition.ademe.fr/particuliers/conso/alimentation/pourquoi-gaspillons-autant-nourriture)
     
-  note: Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
+  note: |
+    Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
   références: 
     - https://www.ademe.fr/operation-foyers-temoins-estimer-impacts-gaspillage-alimentaire-menages
 

--- a/data/alimentation/alimentation.yaml
+++ b/data/alimentation/alimentation.yaml
@@ -846,8 +846,11 @@ alimentation . gaspillage alimentaire:
          alors: 29
 
 alimentation . gaspi alimentaire . fréquence:
-  question: A quelle fréquence jetez-vous des aliments (qu'ils aient été cuisiné ou non) ?
+  question: À quelle fréquence jetez-vous des aliments (qu'ils aient été cuisiné ou non) ?
   par défaut: souvent
+  description: |
+    Si vous ne faites pas particulièrement d'efforts pour ne pas jeter vos aliments, répondez "souvent" : en moyenne, le gaspillage alimentaire reste la norme. 
+    
   une possibilité: 
       choix obligatoire: oui
       possibilités: 

--- a/data/alimentation/alimentation.yaml
+++ b/data/alimentation/alimentation.yaml
@@ -832,18 +832,17 @@ alimentation . déchets . facteur:
         alors: 0.6
       - sinon: 0.3
 
-
 alimentation . gaspillage alimentaire:
   icônes: 🍲🚯
   unité: kgCO2e
   formule:
     variations:
       - si: fréquence = 'souvent'
-         alors: 60
-       - si: fréquence = 'parfois'
-         alors: 45
-       - si: fréquence = 'jamais'
-         alors: 29
+        alors: 60
+      - si: fréquence = 'parfois'
+        alors: 45
+      - si: fréquence = 'jamais'
+        alors: 29
   note: |
     Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
 
@@ -851,18 +850,22 @@ alimentation . gaspillage alimentaire:
     Notons aussi que le détail n'est pas donné quand à l'empreinte des 60kgCO2e : inclut-elle l'empreinte des déchets "inévitables" ? Cette empreinte n'est-elle pas un double comptage avec une empreinte déjà intégrée dans les variables repas ? Nous mettons de côté ces interrogations pour prévilégier le fait de communiquer déjà cet ordre de grandeur.
 
     Pour aller plus loin dans cette discussion, notamment les questions de périmètre et de comparaison avec l'étude internationale de la FAO, voir nos commentaires [ici](https://github.com/datagir/nosgestesclimat/pull/1096#issuecomment-945158967).
-  références: 
+  références:
     - https://www.ademe.fr/sites/default/files/assets/documents/estimer-impacts-du-gaspillage-alimentaire-des-menages.pdf
 
-alimentation . gaspi alimentaire . fréquence:
-  question: À quelle fréquence jetez-vous des aliments (qu'ils aient été cuisiné ou non) ?
-  par défaut: souvent
+alimentation . gaspillage alimentaire . fréquence:
+  question: À quelle fréquence jetez-vous des aliments (qu'ils aient été cuisinés ou non) ?
+  par défaut: "'souvent'"
   description: |
-    Si vous ne faites pas particulièrement d'efforts pour ne pas jeter vos aliments, répondez "souvent" : en moyenne, le gaspillage alimentaire reste la norme. 
-    
-  une possibilité: 
+    Si vous ne faites peu d'efforts pour ne pas jeter vos aliments, répondez "souvent" : en moyenne, le gaspillage alimentaire reste la norme.
+  formule:
+    une possibilité:
       choix obligatoire: oui
-      possibilités: 
+      possibilités:
         - souvent
         - parfois
         - jamais
+
+alimentation . gaspillage alimentaire . fréquence . souvent:
+alimentation . gaspillage alimentaire . fréquence . parfois:
+alimentation . gaspillage alimentaire . fréquence . jamais:

--- a/data/alimentation/alimentation.yaml
+++ b/data/alimentation/alimentation.yaml
@@ -844,6 +844,15 @@ alimentation . gaspillage alimentaire:
          alors: 45
        - si: fréquence = 'jamais'
          alors: 29
+  note: |
+    Dans le document en référence, page 7 pour l'empreinte du gaspillage et page 36 pour la réduction moyenne.
+
+    Notons que l'étude n'est pas forcément évidente à suivre, car le détail du calcul des l'empreinte climat n'y est pas. Le calcul est fait sur une population non représentative, puis corrigée avec des statistiques MODECOM, qui font passer l'empreinte de 34kgCO2e à 60kgCO2e. 
+    Notons aussi que le détail n'est pas donné quand à l'empreinte des 60kgCO2e : inclut-elle l'empreinte des déchets "inévitables" ? Cette empreinte n'est-elle pas un double comptage avec une empreinte déjà intégrée dans les variables repas ? Nous mettons de côté ces interrogations pour prévilégier le fait de communiquer déjà cet ordre de grandeur.
+
+    Pour aller plus loin dans cette discussion, notamment les questions de périmètre et de comparaison avec l'étude internationale de la FAO, voir nos commentaires [ici](https://github.com/datagir/nosgestesclimat/pull/1096#issuecomment-945158967).
+  références: 
+    - https://www.ademe.fr/sites/default/files/assets/documents/estimer-impacts-du-gaspillage-alimentaire-des-menages.pdf
 
 alimentation . gaspi alimentaire . fréquence:
   question: À quelle fréquence jetez-vous des aliments (qu'ils aient été cuisiné ou non) ?

--- a/data/alimentation/alimentation.yaml
+++ b/data/alimentation/alimentation.yaml
@@ -17,6 +17,7 @@ alimentation:
       - local . empreinte
       - boisson
       - déchets
+      - gaspillage alimentaire
         # à venir peut-être dans une prochaine version
         # - laitages
 
@@ -830,3 +831,26 @@ alimentation . déchets . facteur:
       - si: niveau d'engagement = 'en partie'
         alors: 0.6
       - sinon: 0.3
+
+
+alimentation . gaspillage alimentaire:
+  icônes: 🍲🚯
+  unité: kgCO2e
+  formule:
+    variations:
+      - si: fréquence = 'souvent'
+         alors: 60
+       - si: fréquence = 'parfois'
+         alors: 45
+       - si: fréquence = 'jamais'
+         alors: 29
+
+alimentation . gaspi alimentaire . fréquence:
+  question: A quelle fréquence jetez-vous des aliments (qu'ils aient été cuisiné ou non) ?
+  par défaut: souvent
+  une possibilité: 
+      choix obligatoire: oui
+      possibilités: 
+        - souvent
+        - parfois
+        - jamais


### PR DESCRIPTION
A voir si on l'insère cette question sur le gaspi alimentaire car il s'agit en quelque sorte d'un double comptage avec ce qui est comptabilisé dans la variable déchets.
Cependant, cela est plus logique de trouver cette question ici (que dans le volet action) et de proposer directement une action en fonction de la réponse.

Dans l'idéal, il faudrait retravailler l'évaluation GES de la partie déchets en essayant de sortir la partie propre au gaspi alimentaire qui elle serait traitée via cette question