### PR TITLE
Prise en compte des réseaux de chaleur

### DIFF
--- a/data/logement/logement.yaml
+++ b/data/logement/logement.yaml
@@ -283,5 +283,48 @@ logement . chauffage . fioul . intensité carbone litre:
   références:
     - https://www.bilans-ges.ademe.fr - Fioul domestique France continental
 
+logement . chauffage . réseau de chaleur:
+  icônes: 🕸️
+  applicable si: présent
+  titre: Réseau de chaleur
+  formule: consommation * intensité carbone réseau
+
+logement . chauffage . réseau de chaleur . présent:
+  question: Votre logement est-il chauffé via un réseau de chaleur ?
+  par défaut: non
+  
+logement . chauffage . réseau de chaleur . ville:
+  applicable si: présent
+  question: Veuillez renseigner le code postal de la ville ou vous vivez ?
+
+logement . chauffage . réseau de chaleur . estimation via le prix:
+  question: Pas de facture ? Entrez vos dépenses approximatives en chaleur par mois
+  unité: €/kWh
+  formule: 0.8887
+  description: |
+    Cette formule nous permet de passer des €/mois aux kWh/an.
+    Source : A trouver !
+  références:
+    écologie.gouv.fr: https://www.ecologie.gouv.fr/prix-des-produits-petroliers
+
+logement . chauffage . réseau de chaleur . consommation:
+  question: Quelle est la consommation annuelle de chaleur de votre foyer ?
+  unité: kWh
+  description: |
+    Astuce : Vous trouverez vos consommations annuelles d'énergie sur vos factures ou sur votre compte en ligne sur le site de votre fournisseur.
+    Si vous utilisez plusieurs logements (par exemple une residence secondaire) il faut se débrouiller pour "ramener" ces consommations dans celles du logement principal.
+
+  par défaut: 5000 kWh
+  aide: estimation via le prix
+
+logement . chauffage . réseau de chaleur . intensité carbone réseau:
+  formule: 0.324
+  unité: kgCO2e/kWh
+  # ici il faudrait pointer sur le FE du réseau de chaleur renseigné. Cf. Issue 872
+  # Mais quel FE utilisé car il y a une différence entre ceux de la Base Carbone et ceux de [Viaseva](https://carto.viaseva.org/public/viaseva/map/?coord=48.91612966995868,2.373905181884766&zoom=13&typeFilter=existing&typeSource=all&hotColdFilter=hot)
+  # Ex: Réseau de chaleur de Saint-Ouen : Base Carbone 61 gCO2/kWh et Viaseva : 113 gCO2/kWh ; Ex2: Réseau de chaleur de Saint-Denis : Base Carbone 183 gCO2/kWh et Viaseva : 129 gCO2/kWh
+  # J'ai tendance à penser que les FE de Viaseva sont actualisés via l'enquête sur les réseaux de chaleur et de froid réalisée par le  syndicat national du chauffage urbain et de la climatisation urbaine (SNCU)
+  # Les FE de la Base Carbone datent eux de 2019.
+
   
   


### PR DESCRIPTION
** Travail préliminaire ** 

Je dégrossi le travail pour l'introduction des réseaux de chaleur

**Une grosse partie du travail se trouve du côté du dev** pour identifier le réseau de chaleur de l'utilisateur. Plusieurs façons de faire sont possibles : 
- on lui demande de sélectionner le réseau de chaleur de sa ville/le plus prêt de chez lui dans un menu déroulant. Ce menu déroulant listerait tout les FE de réseau de chaleur de la Base Carbone (environ 700). Désavantage : les FE des réseaux de chaleurs peuvent fluctuer et les données de la Base Carbone datent de 2019.
- on demande à l'utilisateur de renseigner son code postal et on arrive à pointer sur la carte Viaseva (cf. #872). Mais est-ce possible de réussir ce pointage ?

Autres tâches à faire : 
- Sourcer et trouver une valeur de conversion pour l'estimation via le prix
- Il faudra également rajouter dans la mosaïque une option réseau de chaleur