### PR TITLE
Retours suite atelier convention

### DIFF
--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -155,7 +155,10 @@ alimentation . manger local:
     variations:
       - si: local . consommation = 'jamais'
         alors: local . part locale annuelle
-      - sinon: local . part locale annuelle * 0.5
+      - si: local . consommation = 'parfois'
+        alors: local . part locale annuelle * 0.666
+      - si: local . consommation = 'souvent'
+        alors: local . part locale annuelle * 0.333
   description: |
     L’alimentation locale permet en effet de réduire les distances de transports des produits que nous consommons. Cependant, même si cela peut sembler contre intuitif l'alimentation
     locale peut, en fonction des cas considérés, être défavorable en terme d'émissions de gaz à effet de serre : l'impact de la provenance de nos produits ne peut être 
@@ -189,7 +192,10 @@ alimentation . manger de saison:
     variations:
       - si: de saison . consommation = 'jamais'
         alors: de saison . part saisonable / de saison . ratio
-      - sinon: (de saison . part saisonable / de saison . ratio) * 0.5
+      - si: de saison . consommation = 'parfois'
+        alors: (de saison . part saisonable / de saison . ratio) * 0.666
+      - si: de saison . consommation = 'souvent'
+        alors: (de saison . part saisonable / de saison . ratio) * 0.333
   description: |
     Contrairement à ce qu'on pourrait imaginer, l'impact de cette action est relativement faible car la part de produits saisonables est très faible dans l'alimentation moyenne d'un français.
 

--- a/data/alimentation/actions/alimentation.yaml
+++ b/data/alimentation/actions/alimentation.yaml
@@ -151,14 +151,7 @@ alimentation . manger local:
   titre: Manger essentiellement des produits locaux
   icônes: 🍅🇫🇷
   effort: faible
-  formule:
-    variations:
-      - si: local . consommation = 'jamais'
-        alors: local . part locale annuelle
-      - si: local . consommation = 'parfois'
-        alors: local . part locale annuelle * 0.666
-      - si: local . consommation = 'souvent'
-        alors: local . part locale annuelle * 0.333
+  formule: alimentation . local . empreinte - recalcul
   description: |
     L’alimentation locale permet en effet de réduire les distances de transports des produits que nous consommons. Cependant, même si cela peut sembler contre intuitif l'alimentation
     locale peut, en fonction des cas considérés, être défavorable en terme d'émissions de gaz à effet de serre : l'impact de la provenance de nos produits ne peut être 
@@ -169,6 +162,13 @@ alimentation . manger local:
 
     Il faut garder en tête qu'il s'agit d'une première approche qui sera affinée par la suite. A titre d'exemple, on peut supposer que l'impact de cette action sera
     plus importante pour les régimes végétalisés, ce qui n'est pas pris en compte ici.
+
+alimentation . manger local . recalcul:
+  formule:
+    recalcul:
+      règle: alimentation . local . empreinte
+      avec:
+        alimentation . local . consommation: "'oui toujours'"
 
 alimentation . gaspillage alimentaire:
   inactive: oui
@@ -188,14 +188,7 @@ alimentation . manger de saison:
   titre: Manger en respectant les saisons
   icônes: 🍅🌞
   effort: faible
-  formule:
-    variations:
-      - si: de saison . consommation = 'jamais'
-        alors: de saison . part saisonable / de saison . ratio
-      - si: de saison . consommation = 'parfois'
-        alors: (de saison . part saisonable / de saison . ratio) * 0.666
-      - si: de saison . consommation = 'souvent'
-        alors: (de saison . part saisonable / de saison . ratio) * 0.333
+  formule: alimentation . de saison . empreinte - recalcul
   description: |
     Contrairement à ce qu'on pourrait imaginer, l'impact de cette action est relativement faible car la part de produits saisonables est très faible dans l'alimentation moyenne d'un français.
 
@@ -205,6 +198,13 @@ alimentation . manger de saison:
     plus importante pour les régimes végétalisés, ce qui n'est pas pris en compte ici.
   note: |
     Pour en savoir plus sur la méthode de calcul, parcourez sa formule, les variables seront expliquées.
+
+alimentation . manger de saison . recalcul:
+  formule:
+    recalcul:
+      règle: alimentation . de saison . empreinte
+      avec:
+        alimentation . de saison . consommation: "'oui toujours'"
 
 alimentation . boisson . eau en bouteille . arrêter:
   applicable si: affirmatif

--- a/data/alimentation/alimentation.yaml
+++ b/data/alimentation/alimentation.yaml
@@ -656,10 +656,12 @@ alimentation . local . consommation:
     possibilités:
       - jamais
       - parfois
+      - souvent
       - oui toujours
 
 alimentation . local . consommation . jamais:
 alimentation . local . consommation . parfois:
+alimentation . local . consommation . souvent:
 alimentation . local . consommation . oui toujours:
 
 alimentation . local . niveau:
@@ -668,9 +670,12 @@ alimentation . local . niveau:
     variations:
       - si: consommation = 'oui toujours'
         alors: 100%
-      - sinon: 50%
+      - si: consommation = 'souvent'
+        alors: 66.6%
+      - si: consommation = 'parfois'
+        alors: 33.3%
   description: |
-    On applique un coefficient de 0,5 dans le cas ou l'utilisateur indique qu'il ne consomme pas exclusivement de saison.
+    On applique un coefficient de 0,333 et 0,666 dans le cas ou l'utilisateur indique qu'il consomme respectivement "parfois" ou "souvent" local.
 
 alimentation . local . part locale annuelle:
   formule: part locale * nombre de semaines
@@ -722,10 +727,12 @@ alimentation . de saison . consommation:
       possibilités:
         - jamais
         - parfois
+        - souvent
         - oui toujours
 
 alimentation . de saison . consommation . jamais:
 alimentation . de saison . consommation . parfois:
+alimentation . de saison . consommation . souvent:
 alimentation . de saison . consommation . oui toujours:
 
 alimentation . de saison . niveau:
@@ -733,9 +740,12 @@ alimentation . de saison . niveau:
     variations:
       - si: consommation = 'oui toujours'
         alors: 100%
-      - sinon: 50%
+      - si: consommation = 'souvent'
+        alors: 66.6%
+      - si: consommation = 'parfois'
+        alors: 33.3%
   description: |
-    On applique un coefficient de 0,5 dans le cas ou l'utilisateur indique qu'il ne consomme pas exclusivement de saison.
+    On applique un coefficient de 0,333 et 0,666 dans le cas ou l'utilisateur indique qu'il consomme respectivement "parfois" ou "souvent" de saison.
 
 alimentation . de saison . ratio:
   formule: 2.42

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -60,7 +60,7 @@ transport . éco-conduite:
   titre: Adopter une éco-conduite
   effort: faible
   icônes: 🚗☮
-  formule: transport . voiture . empreinte . usage * 15%
+  formule: transport . voiture . empreinte - transport . éco-conduite . recalcul
   description: |
     L’éco-conduite est une action simple et efficace qui se tient à la portée de tous.  
 
@@ -73,6 +73,20 @@ transport . éco-conduite:
 
   références:
     Guide de formation à l'éco-conduite ADEME-LaPoste: https://www.ademe.fr/sites/default/files/assets/documents/66885_guide_ecoconduite.pdf#page=8
+
+transport . éco-conduite . recalcul:
+  formule:
+    recalcul:
+      règle: transport . voiture . empreinte
+      avec:
+        transport . voiture . empreinte . usage: transport . éco-conduite . usage réduit
+      # Impossible to change directly the rule we want to replace
+      # Can't do this : transport . voiture . empreinte . usage: transport . voiture . empreinte . usage * 0.85
+
+transport . éco-conduite . usage réduit:
+  formule: (transport . voiture . km * transport . voiture . empreinte . au kilomètre) * 0.85
+  unité: kgCO2e
+  note: réduction de 15% (cf info règle éco-conduite)
 
 transport . boulot:
   icônes: 🏢

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -257,7 +257,7 @@ transport . boulot . télétravail:
       - compatible
       - voiture . km > seuil d'activation
       - jours travaillés en voiture > 0
-  formule: empreinte jour voiture * jours gagnés * 47
+  formule: empreinte jour voiture * jours gagnés * transport . boulot . semaines
 
 transport . boulot . jours gagnés:
   valeur: jours télétravaillés

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -98,7 +98,7 @@ transport . boulot . covoiturage:
       - voiture . propriétaire
       - voiture . km > seuil d'activation
   icônes: 🚗👥
-  formule: distance . année * voiture . empreinte . au kilomètre * réduction covoiturage
+  formule: distance * voiture . empreinte . au kilomètre * réduction covoiturage
   description: |
     Si le covoiturage longue distance est bien connu en France, celui des courtes distances est presque inexistant : aujourd’hui seuls 3 % des déplacements domicile-travail sont réalisés en covoiturage.
 
@@ -119,17 +119,19 @@ transport . réduction covoiturage:
     - https://theconversation.com/a-quelles-conditions-le-covoiturage-sera-t-il-un-mode-de-transport-durable-124122
     - https://www.sciencedirect.com/science/article/pii/S1361920918303201
 
-transport . boulot . distance . année:
+transport . boulot . distance:
   formule: semaines * hebdomadaire
 
 transport . boulot . semaines:
   formule: 47
+  unité: semaines
   description: 47 semaines, plutôt que 52 pour prendre en compte les 5 semaines de congés.
 
 transport . boulot . distance . hebdomadaire:
-  formule: distance * 2 * jours travaillés en voiture
+  formule: km aller * 2 * jours travaillés en voiture
+  unité: km/semaine
 
-transport . jours travaillés en voiture:
+transport . boulot . jours travaillés en voiture:
   question: Combien de jours par semaine prenez-vous votre voiture pour aller au travail ?
   par défaut: 4 jours
   unité: jours
@@ -141,7 +143,7 @@ transport . jours travaillés en voiture:
     4: 4
     5: 5
 
-transport . boulot . distance:
+transport . boulot . distance . km aller:
   question: A quelle distance de chez vous se situe votre travail ?
   unité: km
   description: |
@@ -177,7 +179,7 @@ transport . boulot . commun:
     >💡 Le saviez-vous ? L'État et beaucoup de régions ou villes subventionnent les vélos mécaniques, électriques, cargo, pliants, etc. [Calculez votre aide 🚲️ en 3 clics](https://mesaidesvelo.fr).
 
   applicable si: voiture . km > seuil d'activation
-  formule: boulot . distance . année * gain empreinte au km
+  formule: boulot . distance * gain empreinte au km
 
 transport . boulot . seuil d'activation:
   description: |
@@ -200,60 +202,45 @@ transport . boulot . commun . empreinte:
     variations:
       - si: type = 'bus'
         alors: bus . empreinte
-      - si: type = 'tramway'
-        alors: tramway . empreinte
       - si: type = 'TER'
         alors: TER . empreinte
-      - si: type = 'métro'
-        alors: métro . empreinte
+      - si: type = 'métro ou tramway'
+        alors: métro ou tramway . empreinte
       - si: type = 'vélo'
         alors: vélo . empreinte
 
 transport . boulot . commun . type:
   question: Si vous deviez ne plus prendre votre voiture pour vous rendre au travail quel autre moyen de transport pourriez-vous utiliser ?
-  par défaut: "'bus'"
+  par défaut: "'métro ou tramway'"
   formule:
     une possibilité:
       choix obligatoire: oui
       possibilités:
         - bus
-        - tramway
-        - métro
+        - métro ou tramway
         - TER
         - vélo
 
 transport . boulot . commun . type . bus:
-transport . boulot . commun . type . métro:
-transport . boulot . commun . type . tramway:
+transport . boulot . commun . type . métro ou tramway:
 transport . boulot . commun . type . TER:
 transport . boulot . commun . type . vélo:
 
 transport . bus . empreinte:
-  formule: 0.129
+  formule: transport . bus . impact par km
   unité: kgCO2e/km
-  description: |
-    Base Carbone consultée le 02/10/20 Autobus moyen - Agglomération de plus de 250 000 habitants
 
 transport . TER:
 transport . TER . empreinte:
-  formule: 0.0248
+  formule: transport . train . TER
   unité: kgCO2e/km
   description: |
-    Base Carbone consultée le 02/10/20 TER - 2019 - Traction moyenne
+    On considère qu'un déplacement domicile travail effectué en voiture peut-être remplacé par un train régional et non par un TGV.
 
-transport . métro:
-transport . métro . empreinte:
-  formule: 0.0025
+transport . métro ou tramway:
+transport . métro ou tramway . empreinte:
+  formule: transport . métro ou tram . impact par km
   unité: kgCO2e/km
-  description: |
-    Base Carbone consultée le 02/10/20 Métro - 2019 - Île-de-France
-
-transport . tramway:
-transport . tramway . empreinte:
-  formule: 0.0022
-  unité: kgCO2e/km
-  description: |
-    Base Carbone consultée le 02/10/20 Tramway - 2019 - Île-de-France
 
 transport . boulot . télétravail:
   titre: Faire du télétravail

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -75,6 +75,7 @@ transport . éco-conduite:
     Guide de formation à l'éco-conduite ADEME-LaPoste: https://www.ademe.fr/sites/default/files/assets/documents/66885_guide_ecoconduite.pdf#page=8
 
 transport . éco-conduite . recalcul:
+  note: Un recalcul est nécessaire ici, car l'utilisateur peut avoir utilisé l'outil d'aide à la saisie qui proratise alors la variable km au nombre de voyageurs. Sinon ce n'est pas le cas.
   formule:
     recalcul:
       règle: transport . voiture . empreinte

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -286,7 +286,7 @@ transport . boulot . télétravail . compatible:
 transport . voiture 5km:
   titre: Se passer de voiture pour moins de 5 km
   icônes: 🚗🚲
-  formule: distance totale * voiture . empreinte . au kilomètre
+  formule: transport . voiture . empreinte - transport . voiture 5km . recalcul
   non applicable si: voiture . km < seuil d'activation
   description: |
     En France, 4 trajets en voiture sur 10 font moins de 3 km et ce n’est pas moins de 177 millions de trajets de moins de 5km qui sont réalisés seuls en voiture chaque semaine (hors trajets domicile-travail). 
@@ -310,6 +310,17 @@ transport . voiture 5km . seuil d'activation:
 
   formule: nombre de semaines * distance moyenne . aller-retour
   unité: km
+
+transport . voiture 5km . recalcul:
+  formule:
+    recalcul:
+      règle: transport . voiture . empreinte
+      avec:
+        transport . voiture . empreinte . usage: transport . voiture 5km . usage réduit
+
+transport . voiture 5km . usage réduit:
+  formule: (transport . voiture . km - distance totale) * transport . voiture . empreinte . au kilomètre
+  unité: kgCO2e
 
 transport . voiture 5km . distance totale:
   formule: fréquence * distance moyenne . aller-retour * nombre de semaines

--- a/data/transport/transport . voiture.yaml
+++ b/data/transport/transport . voiture.yaml
@@ -217,7 +217,7 @@ transport . voiture . empreinte . au kilomètre:
 
     Nous avons donc pour l'instant retenu le calcul du calculateur MicMac qui est la base de Nos Gestes Climat, dont la source est malheureusement inaccessible : 
 
-    > Hybride : enlever 15 % aux consommations ci-dessus (source ADEME : http://www2.ademe.fr/servlet/KBaseShow?catid=13655)
+    > Hybride : enlever 15% aux consommations ci-dessus (source ADEME: http://www2.ademe.fr/servlet/KBaseShow?catid=13655)
 
 transport . voiture . thermique . empreinte au litre:
   description: |

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -67,6 +67,7 @@ transport . train:
 transport . train . impact par km:
   formule: 0.0056
   unité: kgCO2e/km
+
 transport . train . km:
   question: Combien de kilomètres parcourez-vous en train par an ?
   description: Les suggestions sont basées sur la distance à vol d'oiseau doublée pour considérer un aller-retour.
@@ -85,14 +86,23 @@ transport . métro ou tram:
   formule: heures par semaine * impact par heure * nombre de semaines
 
 transport . métro ou tram . impact par heure:
-  formule: 0.17
+  formule: impact par km * vitesse
   unité: kgCO2e/heures
   note: Nous avons confondu tram et métro, alors que le modèle MicMac v2.6 ne parle que de métro.
   description: |
-    Sur la base de 6,63 gCO2e/(passager.km) et de 25 km/h de vitesse moyenne. Base Carbone consultée le 22/06/19- Métro/tram/Trolley, réseaux urbains Classe 1 - amont et combustion ; transports.blog.lemonde.fr, consulté le 05/09/2014
+    Sur la base de 6,63 gCO2e/(passager.km) et de 25 km/h de vitesse moyenne.
+
+transport . métro ou tram . impact par km:
+  formule: 0.00663
+  unité: kgCO2e/heures
+  note: Base Carbone consultée le 22/06/19- Métro/tram/Trolley, réseaux urbains Classe 1 - amont et combustion
+
+transport . métro ou tram . vitesse:
+  formule: 25
+  unité: km/heure
+  note: Hypothèse de 25 km/h de vitesse moyenne, transports.blog.lemonde.fr, consulté le 05/09/2014
   références:
     - http://transports.blog.lemonde.fr/2013/03/11/les-petits-secrets-de-la-ratp-reveles-au-public/
-      - http://www.bilans-ges.ademe.fr/
 
 transport . métro ou tram . heures par semaine:
   question: Combien d'heures passez-vous par semaine en métro ou en tram ?
@@ -114,13 +124,22 @@ nombre de semaines:
   unité: semaine
 
 transport . bus . impact par heure:
-  formule: 1.99
-  unité: kgCO2e/heure
+  formule: impact par km * vitesse
+  unité: kgCO2e/heures
   description: |
-    Sur la base de 166 gCO2e/(passager.km) et de 12 km/h de vitesse moyenne - Base Carbone consultée le 22/06/19 - Bus, moyen, réseaux urbains Classe 2 (zone urbaine et interurbaine) - amont et combustion ; Mairie de Paris pour la vitesse des bus, consulté le 05/09/2014
+    Sur la base de 166 gCO2e/(passager.km) et de 12 km/h de vitesse moyenne
+
+transport . bus . impact par km:
+  formule: 0.166
+  unité: kgCO2e/heures
+  note: Base Carbone consultée le 22/06/19 - Bus, moyen, réseaux urbains Classe 2 (zone urbaine et interurbaine) - amont et combustion
+
+transport . bus . vitesse:
+  formule: 12
+  unité: km/heure
+  note: Hypothèse de 12 km/h de vitesse moyenne, Mairie de Paris, consulté le 05/09/2014
   références:
     - http://www.paris.fr/pratique/deplacements-voirie/transports-en-commun/promouvoir-les-transports-collectifs/rub_385_stand_10755_port_1208
-    - http://www.bilans-ges.ademe.fr/
 
 transport . bus . heures par semaine:
   question: Combien d'heures passez-vous dans un bus par semaine ?

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -150,7 +150,7 @@ transport . bus . impact par km:
   unité: kgCO2e/heures
   note: |
     Autobus - Gazole ; 113 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
-    La flotte étant majoriatirement Diesel en France, on fait le choix de prendre ce FE (plus fiable que la référence "Autobus moyen" selon la base carbone)
+    La flotte étant majoriatirement Diesel en France (https://www.statistiques.developpement-durable.gouv.fr/69-000-autocars-en-circulation-au-1er-janvier-2020), on fait le choix de prendre ce FE (plus fiable que la référence "Autobus moyen" selon la base carbone)
     La prise compte des autres motorisations de cette catégorie de la base carbone fera diminuer ce FE (en pondérant selon les caractéristiques de la flotte française). (Ex: Autobus - Electrique = 21.7 gCO2e/km/personne)
 
 transport . bus . vitesse:

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -146,9 +146,9 @@ transport . bus . impact par heure:
     Sur la base de 166 gCO2e/(passager.km) et de 12 km/h de vitesse moyenne
 
 transport . bus . impact par km:
-  formule: 0.166
+  formule: 0.151
   unité: kgCO2e/heures
-  note: Base Carbone consultée le 22/06/19 - Bus, moyen, réseaux urbains Classe 2 (zone urbaine et interurbaine) - amont et combustion
+  note: Autobus moyen - Agglomération de plus de 250 000 habitants ; 151 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
 
 transport . bus . vitesse:
   formule: 12

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -109,9 +109,9 @@ transport . métro ou tram . impact par heure:
     Sur la base de 6,63 gCO2e/(passager.km) et de 25 km/h de vitesse moyenne.
 
 transport . métro ou tram . impact par km:
-  formule: 0.00663
+  formule: 0.00329
   unité: kgCO2e/heures
-  note: Base Carbone consultée le 22/06/19- Métro/tram/Trolley, réseaux urbains Classe 1 - amont et combustion
+  note: Métro, tramway, trolleybus - 2018 - Agglomération > à 250 000 habitants ; 3.29 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
 
 transport . métro ou tram . vitesse:
   formule: 25

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -67,6 +67,7 @@ transport . train:
 transport . train . impact par km:
   formule: 0.0056
   unité: kgCO2e/km
+  note: pas de source !
 
 transport . train . km:
   question: Combien de kilomètres parcourez-vous en train par an ?
@@ -232,14 +233,14 @@ transport . deux roues thermique . empreinte:
       - si: type = 'moto inf 250'
         alors: 0.0616 kgCO2e/km
       - si: type = 'moto sup 250'
-        alors: 0.168 kgCO2e/km
+        alors: 0.191 kgCO2e/km
 
   note: |
-    Scooter ; 64.4 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
+    Cyclomoteur - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
-    Deux roues thermiques < 250cm3 ; 61,6 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
+    Moto =< 250 cm3 - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
-    Deux roues thermiques > 250cm3 ; 168 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
+    Moto > 250 cm3 - Mixte - 2018 ; 191 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
 
     Nous ne prenons en compte que l'empreinte à l'usage, pas la construction, faute de données.

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -65,9 +65,24 @@ transport . train:
   formule: km * impact par km
 
 transport . train . impact par km:
-  formule: 0.0056
+  formule: (TER + TGV) / 2
   unité: kgCO2e/km
-  note: pas de source !
+  note: |
+    Nous faisons le choix de ne pas différencier TGV et TER pour le moment (pour éviter de poser deux questions)
+    On pourrait ajouter un curseur pour évaluer la pondération de la moyenne et être plus précis. Aujourd'hui on est à 50/50.
+    On prend donc le facteur d'émission moyen entre TER et TGV.
+
+transport . train . TER:
+  formule: 0.0296
+  unité: kgCO2e/km
+  note: |
+    TER - 2019 - Traction moyenne ; 29.6 gCO2e/km/personne ; Base Carbone (Données SNCF)
+
+transport . train . TGV:
+  formule: 0.00236
+  unité: kgCO2e/km
+  note: |
+    TGV - 2019 ; 2.36 gCO2e/km/personne ; Base Carbone (Données SNCF)
 
 transport . train . km:
   question: Combien de kilomètres parcourez-vous en train par an ?

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -76,13 +76,13 @@ transport . train . TER:
   formule: 0.0296
   unité: kgCO2e/km
   note: |
-    TER - 2019 - Traction moyenne ; 29.6 gCO2e/km/personne ; Base Carbone (Données SNCF)
+    TER - 2019 - Traction moyenne ; 29.6 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022 (Données SNCF)
 
 transport . train . TGV:
   formule: 0.00236
   unité: kgCO2e/km
   note: |
-    TGV - 2019 ; 2.36 gCO2e/km/personne ; Base Carbone (Données SNCF)
+    TGV - 2019 ; 2.36 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022 (Données SNCF)
 
 transport . train . km:
   question: Combien de kilomètres parcourez-vous en train par an ?

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -261,9 +261,7 @@ transport . deux roues thermique . empreinte:
     Moto > 250 cm3 - Mixte - 2018 ; 191 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
 
-    Nous ne prenons en compte que l'empreinte à l'usage, pas la construction, faute de données.
-
-    Notons cependant que si l'on estime la fabrication à une tonne de CO2e, un véhicule qui ferait 100 000 km émetterait ~ 10 tonnes de CO2e, soit 10x l'empreinte de construction.
+    Les chiffres ci-dessus incluent la fabrication du véhicule, contrairement aux données précédentes (2021).
 
   références:
     documentation bilan-GES: https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -244,9 +244,9 @@ transport . deux roues thermique . empreinte:
   formule:
     variations:
       - si: type = 'scooter'
-        alors: 0.0644 kgCO2e/km
+        alors: 0.0763 kgCO2e/km
       - si: type = 'moto inf 250'
-        alors: 0.0616 kgCO2e/km
+        alors: 0.0763 kgCO2e/km
       - si: type = 'moto sup 250'
         alors: 0.191 kgCO2e/km
 

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -146,9 +146,12 @@ transport . bus . impact par heure:
     Sur la base de 166 gCO2e/(passager.km) et de 12 km/h de vitesse moyenne
 
 transport . bus . impact par km:
-  formule: 0.151
+  formule: 0.113
   unité: kgCO2e/heures
-  note: Autobus moyen - Agglomération de plus de 250 000 habitants ; 151 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
+  note: |
+    Autobus - Gazole ; 113 gCO2e/km/personne ; Base Carbone consultée le 04/04/2022
+    La flotte étant majoriatirement Diesel en France, on fait le choix de prendre ce FE (plus fiable que la référence "Autobus moyen" selon la base carbone)
+    La prise compte des autres motorisations de cette catégorie de la base carbone fera diminuer ce FE (en pondérant selon les caractéristiques de la flotte française). (Ex: Autobus - Electrique = 21.7 gCO2e/km/personne)
 
 transport . bus . vitesse:
   formule: 12


### PR DESCRIPTION
Quelques retours rapidement "corrigeables" suite à l'atelier "ADEME 30 ans" : 

- [x] L'action "eco conduite" ne prend pas en compte les voyageurs
- [x] Investiguer pour vérifier que c'est la seule action qui bug
- [x] Profiter de cette PR pour revoir rapidement les FE transport (train, métro etc..)
- [ ] Pb pour modifier les réponses via le profil lors d'un songage (pas de cas d'usage --> a investiguer)
- [x] Ajouter "Souvent" dans certaines suggestions --> peu pertinent
- [x] Mode conférence : afficher seulement les utilisateurs qui ont un avancement supérieur à xx%