### PR TITLE
Notification biocarburants

### DIFF
--- a/data/conversion-métrique.yaml
+++ b/data/conversion-métrique.yaml
@@ -104,7 +104,10 @@ pétrole . litres essence:
       - deux roues thermique
 
 pétrole . litres essence . voiture:
-  applicable si: transport . voiture . thermique . carburant = 'essence E5 ou E10'
+  applicable si:
+    une de ces conditions:
+      - transport . voiture . thermique . carburant = 'essence E5 ou E10'
+      - transport . voiture . thermique . carburant = 'essence E85'
   formule:
     variations:
       - si: transport . voiture . aide km

--- a/data/transport/transport . voiture.yaml
+++ b/data/transport/transport . voiture.yaml
@@ -232,7 +232,7 @@ transport . voiture . thermique . empreinte au litre:
       - si: carburant = 'essence E5 ou E10'
         alors: 2.7
       - si: carburant = 'essence E85'
-        alors: 2.7 #idem essence (cf note carburant)
+        alors: 1.11
   unité: kgCO2e/l
 
 transport . voiture . thermique . carburant:
@@ -257,7 +257,7 @@ transport . voiture . thermique . carburant:
 
     Par contre, parmi les véhicules neufs, l'essence domine aujourd'hui.
 
-    Si vous sélectionné l'essence E85, le facteur d'émission de l'essence est attribué. En effet, au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
+    Si vous sélectionné l'essence E85, il faut savoir que le facteur d'émission associé n'est pas représentatif des conséquences environnementales liées à l'utilisation des biocarburants. En effet, au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
 
 transport . voiture . thermique . carburant . gazole B7 ou B10:
   titre: Gazole (B7 ou B10)
@@ -270,9 +270,9 @@ transport . voiture . notif carburant:
   type: notification
   formule: thermique . carburant = 'essence E85'
   description: |
-    Votre véhicule roule au biocarburant : au vu des problématiques actuelles liées à l'affectation des sols pour la production de biocarburants, 
-    le facteur d'émission de l'essence E85 disponible est particulièrement incertain. 
-    Pour ne pas introduire d'erreur significative, nous avons fait le choix d'attribuer le facteur d'émission de l'essence E5 ou E10 aux biocarburants.
+    Votre véhicule roule au biocarburant : au vu des problématiques actuelles liées aux **changements d'affectation des sols** pour la production de biocarburants, 
+    le facteur d'émission de l'essence E85 proposé dans la Base Carbone est particulièrement incertain. 
+    Nous avons fait le choix d'ajouter cette option dans le test mais il faut savoir que ce résultat **n'est pas représentatif des conséquences environnementales probables liées à l'utilisation de biocarburants.**
 
 transport . voiture . empreinte . construction:
   formule:

--- a/data/transport/transport . voiture.yaml
+++ b/data/transport/transport . voiture.yaml
@@ -257,7 +257,9 @@ transport . voiture . thermique . carburant:
 
     Par contre, parmi les véhicules neufs, l'essence domine aujourd'hui.
 
-    Si vous sélectionné l'essence E85, il faut savoir que le facteur d'émission associé n'est pas représentatif des conséquences environnementales liées à l'utilisation des biocarburants. En effet, au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
+    Le facteur d'émission associé au biocarburant E85 n'est pas représentatif des conséquences environnementales liées à l'utilisation des biocarburants. 
+    En effet, au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte 
+    (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
 
 transport . voiture . thermique . carburant . gazole B7 ou B10:
   titre: Gazole (B7 ou B10)
@@ -270,8 +272,9 @@ transport . voiture . notif carburant:
   type: notification
   formule: thermique . carburant = 'essence E85'
   description: |
-    Votre véhicule roule au biocarburant : au vu des problématiques actuelles liées aux **changements d'affectation des sols** pour la production de biocarburants, 
-    le facteur d'émission de l'essence E85 proposé dans la Base Carbone est particulièrement incertain. 
+    Votre véhicule roule au biocarburant : Au-delà de l'empreinte carbone des biocarburants, il faut bien avoir conscience qu'ils ont une empreinte au sol : ce sol pourrait être utilisé pour faire pousser des céréales pour nous nourrir ou servir de refuges de biodiversité.
+    C'est ce qu'on appelle le "changement d'affectation des sols" ici à des fins de production de biocarburants. Malheureusement, l'impact sur le climat de ce changement d'affectation est difficile à quantifier et particulièrement incertain.
+
     Nous avons fait le choix d'ajouter cette option dans le test mais il faut savoir que ce résultat **n'est pas représentatif des conséquences environnementales probables liées à l'utilisation de biocarburants.**
 
 transport . voiture . empreinte . construction:

--- a/data/transport/transport . voiture.yaml
+++ b/data/transport/transport . voiture.yaml
@@ -231,8 +231,8 @@ transport . voiture . thermique . empreinte au litre:
         alors: (3.1 + 3.04) / 2
       - si: carburant = 'essence E5 ou E10'
         alors: 2.7
-      # - si: carburant = 'essence E85'
-      #   alors: 1.11
+      - si: carburant = 'essence E85'
+        alors: 2.7 #idem essence (cf note carburant)
   unité: kgCO2e/l
 
 transport . voiture . thermique . carburant:
@@ -251,19 +251,28 @@ transport . voiture . thermique . carburant:
       possibilités:
         - gazole B7 ou B10
         - essence E5 ou E10
-        # - essence E85 -> On choisi pour le moment de ne pas inclure les biocarburants.
+        - essence E85
   note: |
     La domination du couple gazole-essence est écrasante, [source](https://www.leprogres.fr/magazine-automobile/2021/03/27/quels-sont-les-carburants-les-plus-utilises-dans-votre-commune).
 
     Par contre, parmi les véhicules neufs, l'essence domine aujourd'hui.
 
-    Au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
+    Si vous sélectionné l'essence E85, le facteur d'émission de l'essence est attribué. En effet, au vu des problématiques liées au changement d'affectation des sols et autres impacts environnementaux liés à la culture du maïs par exemple, les **biocarburants** ne sont pas pris en compte (le facteur d'émission de la base carbone étant particulièrement incertain). Voir nos discussions [ici](https://github.com/datagir/nosgestesclimat/pull/1324).
 
 transport . voiture . thermique . carburant . gazole B7 ou B10:
   titre: Gazole (B7 ou B10)
 transport . voiture . thermique . carburant . essence E5 ou E10:
   titre: Essence (E5 ou E10)
 transport . voiture . thermique . carburant . essence E85:
+  titre: Essence E85 (biocarburants)
+
+transport . voiture . notif carburant:
+  type: notification
+  formule: thermique . carburant = 'essence E85'
+  description: |
+    Votre véhicule roule au biocarburant : au vu des problématiques actuelles liées à l'affectation des sols pour la production de biocarburants, 
+    le facteur d'émission de l'essence E85 disponible est particulièrement incertain. 
+    Pour ne pas introduire d'erreur significative, nous avons fait le choix d'attribuer le facteur d'émission de l'essence E5 ou E10 aux biocarburants.
 
 transport . voiture . empreinte . construction:
   formule:


### PR DESCRIPTION
Pour faire suite à nos discussions @laem et @Benjamin-Boisserie-ABC j'ai ajouté une notification d'avertissement pour les biocarburants. (lié à #1324)

Personnellement, je ne suis pas satisfait de la solution. J'ai l'impression qu'on pourrait écrire cette notification sur plusieurs questions au vu des incertitudes des FE dans la base carbone... Je suis complètement d'accord de ne pas proposer l'action "passer aux biocarburants" à causes des enjeux associés mais pas d'accord de ne pas proposer ce qui est disponible (même imparfait). Oui on a matière à critiquer ce chiffre mais pourquoi ne pas prendre en compte le FE actuel en mentionnant ce dit la base carbone ? Le périmètre de NGC est le bilan GES de mon point de vue...

> Les travaux existants ou en cours n’ont pas encore réussi à créer des références matures d'un point de vue méthodologiques sur ces sujets. L’étude ACV biocarburants publiée en 2010 à partir de laquelle ont été calculées les valeurs des tableaux ci-dessus n’ayant pas vocation à résoudre cette question complexe, le principe retenu a été de calculer les bilans d‘émissions de GES sans intégrer les changements d’affectation des sols dans le résultat de référence conformément aux recommandations du référentiel de réalisation d’ACV pour les biocarburants. Par contre, l’impact potentiel de différents scénarii de CAS sur les bilans de GES a été examiné ensuite au travers d’une analyse de sensibilité.

https://bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/New_liquides