### PR TITLE
Ajout d’un lien vers un bloqueur de pub

### DIFF
--- a/data/divers/actions/divers.yaml
+++ b/data/divers/actions/divers.yaml
@@ -50,7 +50,7 @@ divers . publicité:
     **Sur mobile**, cela dépend de votre appareil: 
 
     <details><summary>Sur iPhone</summary>L'écosystème iOS [est cadenassé par Apple](https://support.mozilla.org/fr/kb/modules-complementaires-pour-firefox-sous-ios), donc il n'est pas possible de faire grand chose.</details>
-    <details><summary>Sur Android</summary>Vous pouvez utiliser Firefox et y installer l'extension muBlock, ou un autre navigateur du magasin d'application permettant le blocage (ce n'est pas le cas de Chrome). Pour les applications, c'est plus compliqué, mais [Youtube Vanced](https://vancedapp.com) ou [New Pipe](https://newpipe.net) sont des exemples d'alternatives sans pub.</details>
+    <details><summary>Sur Android</summary>Vous pouvez utiliser Firefox et y installer l'extension muBlock, ou un autre navigateur du magasin d'application permettant le blocage (ce n'est pas le cas de Chrome). Pour les applications, c'est plus compliqué, mais il est possible d'installer des alternatives d'applications sans publicité (par exemple [Youtube Vanced](https://vancedapp.com) ou [New Pipe](https://newpipe.net) en remplacement de l'application Youtube) ou d'installer un bloqueur pour toutes les applications (par exemple [Blokada](https://blokada.org/)).</details>
 
   références:
     ADEME: https://librairie.ademe.fr/dechets-economie-circulaire/325-biens-d-equipement-benefices-environnementaux-d-allonger-leur-duree-de-vie.html

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -29,7 +29,7 @@ transport . arrêter l'avion:
 
     On entend souvent que ramenée au passager, elle est du même ordre que celle d'une voiture. C'est vrai, mais ce n'est qu'une partie de l'histoire. 
 
-    Premièrement, l'empreinte de la voiture elle-même est élevée. Comparer l'avion à la voiture, ne rend pas ce premier vertueux.
+    Premièrement, l'empreinte de la voiture elle-même est élevée. Comparer l'avion à la voiture ne rend pas ce premier vertueux.
 
     Deuxièmement, on ne peut comparer la voiture et l'avion simplement parce qu'un trajet en avion est en général bien plus long. Quand il s'agit de choisir la destination des vacances par exemple, un trajet en voiture a donc toutes les chances d'être beaucoup moins polluant. Cela dit, notons aussi que nos kilométrages en voiture sont tels que le match est relancé quand on regarde l'empreinte à l'année.
 


### PR DESCRIPTION
C’est une modification mineure, mais je trouvais intéressant de compléter l’explication qui proposait d’installer des applications alternatives sans publicités : il existe des bloqueurs de pub généraux, qui vont aussi bloquer les publicités dans des applications qui en ont normalement (il bloque l’accès à ses applications à des sites de publicité).