### PR TITLE
ci: fix GH Action from forked repositories

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,8 +1,5 @@
 name: Vérification de la PR
 on:
-  pull_request_target:
-    branches:
-      - '*'
   pull_request:
     types: [ opened, synchronize ]
   push:
@@ -44,26 +41,50 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: build
     steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: find-comment
+      - name: Create artifact
+        run: |
+          mkdir -p artifacts
+          echo "
+          ## 🚀 La _pull request_ #${{ github.event.pull_request.number }}  est ouverte \!
+          > Tester le modèle depuis le site : ${{ needs.build.outputs.test-url }}
+
+          Résultat de la compilation du modèle :
+
+          \`\`\`
+          ${{ needs.build.outputs.compilation-result }}
+          \`\`\`
+          " > artifacts/result.md
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
         with:
-          issue-number: ${{ github.event.pull_request.number }} #e.g. 1
-          comment-author: 'github-actions[bot]'
-          body-includes: '> Tester le modèle depuis le site'
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            ## 🚀 La _pull request_ #${{ github.event.pull_request.number }}  est ouverte !
+          name: pr_message
+          path: artifacts
 
-            > Tester le modèle depuis le site : ${{ needs.build.outputs.test-url }}
-
-            Résultat de la compilation du modèle :
-
-            ```
-            ${{ needs.build.outputs.compilation-result }}
-            ```
+  # post-comment:
+  #   runs-on: ubuntu-22.04
+  #   if: github.event_name == 'pull_request'
+  #   needs: build
+  #   steps:
+  #     - name: Find Comment
+  #       uses: peter-evans/find-comment@v2
+  #       id: find-comment
+  #       with:
+  #         issue-number: ${{ github.event.pull_request.number }} #e.g. 1
+  #         comment-author: 'github-actions[bot]'
+  #         body-includes: '> Tester le modèle depuis le site'
+  #     - name: Create comment
+  #       uses: peter-evans/create-or-update-comment@v2
+  #       with:
+  #         comment-id: ${{ steps.find-comment.outputs.comment-id }}
+  #         issue-number: ${{ github.event.pull_request.number }}
+  #         edit-mode: replace
+  #         body: |
+  #           ## 🚀 La _pull request_ #${{ github.event.pull_request.number }}  est ouverte !
+  #
+  #           > Tester le modèle depuis le site : ${{ needs.build.outputs.test-url }}
+  #
+  #           Résultat de la compilation du modèle :
+  #
+  #           ```
+  #           ${{ needs.build.outputs.compilation-result }}
+  #           ```

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,10 +1,18 @@
 name: Vérification de la PR
 on:
+  pull_request_target:
+    branches:
+      - '*'
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
   push:
     branches:
       - '*'
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
 
 jobs:
   build:
@@ -44,7 +52,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '> Tester le modèle depuis le site'
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/upload-compilation-result.yaml
+++ b/.github/workflows/upload-compilation-result.yaml
@@ -49,12 +49,12 @@ jobs:
           mkdir -p artifacts
           echo "
           ## 🚀 La _pull request_ #${{ github.event.pull_request.number }}  est ouverte \!
-          > Tester le modèle depuis le site : ${{ needs.compile.outputs.test-url }}
+          > Tester le modèle depuis le site : ${{ needs.build.outputs.test-url }}
 
           Résultat de la compilation du modèle :
 
           \`\`\`
-          ${{ needs.compile.outputs.compilation-result }}
+          ${{ needs.build.outputs.compilation-result }}
           \`\`\`
           " > artifacts/result.md
       - name: Upload artifact


### PR DESCRIPTION
Fixes the initial PR #1463 to support pull requests from forked repositories.

**Why?**
For security reasons, pull request comments can't be edited from a workflow triggered by a forked repository -- see https://github.com/datagir/nosgestesclimat/pull/1339#issuecomment-1232733140.

**Solution**
To bypass this issue, this PR setups a new workflow which uploads the result of the model compilation as an artifact which is read by [another workflow](https://github.com/datagir/nosgestesclimat/blob/master/.github/workflows/pr-updater.yaml) in the main repository, before updating the comment in the corresponding PR.

## Changelog

* New GitHub Action: `upload-compilation-result.yml`