### PR TITLE
MAJ des facteurs d'émission via la base carbone

### DIFF
--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -48,9 +48,9 @@ transport . avion . court courrier . vitesse moyenne:
   note: |
     Nous utilisons la vitesse moyenne de vol pour un Paris Toulouse.
 transport . avion . court courrier . empreinte par km:
-  formule: 0.230
-  note: |
-    Nous utilisons le facteur d'émission de la tranche de distance < 1000 km (aller) de [ecolab-transport](https://github.com/betagouv/ecolab-transport/blob/master/ges-transport.yaml#L13).
+  formule: 0.258
+  description: |
+    Nous utilisons le facteur d'émission de la base carbone `Avion passagers - Court courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
 
 transport . avion . court courrier . heures de vol:
@@ -82,9 +82,9 @@ transport . avion . moyen courrier . vitesse moyenne:
   note: |
     Nous utilisons la vitesse moyenne de vol pour un Paris Alger.
 transport . avion . moyen courrier . empreinte par km:
-  formule: (0.186 + 0.178) / 2
-  note: |
-    Nous utilisons la moyenne des facteurs d'émissions des tranches de distance 1000-2000km et 2000-3500km (aller) de [ecolab-transport](https://github.com/betagouv/ecolab-transport/blob/master/ges-transport.yaml#L13).
+  formule: 0.187
+  description: |
+    Nous utilisons le facteur d'émission de la base carbone `Avion passagers - Moyen courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
 
 transport . avion . moyen courrier . heures de vol:
@@ -115,9 +115,9 @@ transport . avion . long courrier . vitesse moyenne:
   note: |
     Nous utilisons la vitesse moyenne de vol du modèle MicMac v2.6, déterminée selon [ces données](http://www.abm.fr/voyager-en-avion-le-guide-du-passager/en-complement/distances-et-durees-de-vol.html).
 transport . avion . long courrier . empreinte par km:
-  formule: 0.151
-  note: |
-    Nous utilisons le facteur d'émissions de la tranche > 3500km (aller) de [ecolab-transport](https://github.com/betagouv/ecolab-transport/blob/master/ges-transport.yaml#L13).
+  formule: 0.152
+  description: |
+    Nous utilisons le facteur d'émission de la base carone `Avion passagers - Long courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
 
 transport . avion . long courrier . heures de vol:


### PR DESCRIPTION
Nous utilisions des valeurs d'une ancienne version de
monimpacttransport.fr

Ceux-ci, classés en 3 catégories plutôt qu'en km, sont mieux adaptés aux
questions posées
