### PR TITLE
Réécriture des questions avion

### DIFF
--- a/data/translated-rules-en-us.yaml
+++ b/data/translated-rules-en-us.yaml
@@ -17010,14 +17010,12 @@ transport . avion:
   description: |
     ![](https://images.unsplash.com/photo-1525624286412-4099c83c1bc8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80)
 
-    The airplane's footprint is substantial. It is not necessarily more
-    polluting *per kilometer* than a car that moves only one person, but the
-    distance and especially the distance covered in one hour (commonly
-    called speed), allows to change continent for a weekend.
+    The footprint of the plane is substantial. It is not necessarily more polluting *per kilometer* than a car that only moves one person,
+    but the distance and especially the distance covered in one hour (commonly called speed), allows to change continent for a weekend.
 
-    Let's also keep in mind that the average French person does not fly or
-    does not fly much. Most of the aviation footprint is therefore
-    concentrated on 10% or less of the French population.
+    Let's also keep in mind that the average French person does not fly or does not fly much. Most of the aviation footprint is therefore concentrated on 10% or less of the French population.
+
+    > For the definition of flight ranges, from short-haul to long-haul, we use <a href="https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530">this discussion</a> from the Base Carbone forum.
   description.lock: |
     ![](https://images.unsplash.com/photo-1525624286412-4099c83c1bc8?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80)
 
@@ -17025,6 +17023,8 @@ transport . avion:
     mais la distance et surtout la distance parcourue en une heure (qu'on appelle couramment la vitesse), permet de changer de continent pour un week-end.
 
     Gardons aussi en tête que le Français moyen ne prend pas ou peu l'avion. L'essentiel de l'empreinte de l'aviation est donc concentrée sur 10% ou moins des Français.
+
+    > Pour la définition des gammes de vol, de court-courrier à long-courrier, nous utilisons [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
   note: |
     We have chosen to ask for the total number of flight hours, rather than
     asking the user to fill in each of his flights via the departure and
@@ -17066,6 +17066,18 @@ transport . avion:
 transport . avion . court courrier:
   titre: short haul
   titre.lock: court courrier
+transport . avion . court courrier . durée max:
+  description: Distance characterizing a short-haul flight based on <a
+    href="https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530">this
+    discussion</a> in the Base Carbone forum.
+  description.lock: Distance caractérisant un vol court-courrier basé sur [cette
+    discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du
+    forum Base Carbone.
+  titre: Short-haul travel time
+  titre.lock: Durée trajet court courrier
+transport . avion . court courrier . durée moyennne:
+  titre: Average time spent by a French person on short-haul flights
+  titre.lock: Durée moyenne passée par un Français dans les vols court-courrier
 transport . avion . court courrier . empreinte par km:
   description: |
     We use the emission factor from the
@@ -17094,8 +17106,16 @@ transport . avion . court courrier . heures de vol:
 
     💡 Ne comptez que les km de déplacement personnel et de déplacement domicile travail pour rejoindre votre lieu de travail habituel.
     Par exemple, si vous êtes en mission professionnelle dans un autre pays, cela rentre dans la comptabilité de votre entreprise.
-  question: How many hours per year do you travel by plane in France?
-  question.lock: Combien d'heures par an voyagez-vous en avion en France métropolitaine ?
+  note: The characterization "short haul" by travel time is given by the rule
+    `short haul . max duration` = 2.17h.
+  note.lock:
+    La caractérisation "court courrier" par le temps de trajet est donnée
+    par la règle `court courrier . durée max` = 2.17h.
+  question:
+    How many hours per year do you travel by plane for short-haul flights
+    (less than 2 hours)?
+  question.lock: Combien d'heures par an voyagez-vous en avion pour des vols
+    court-courrier (trajet de moins de 2h) ?
   suggestions:
     - 🚫✈️
     - Paris🔁Lyon
@@ -17110,6 +17130,25 @@ transport . avion . court courrier . heures de vol:
     - Paris🔁Ajaccio
   titre: flight hours
   titre.lock: heures de vol
+transport . avion . court courrier . km moyen:
+  description: |
+    2016 data from this CWW <a href="https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf">document</a>, including this table: 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  description.lock: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  titre: Total distance traveled by the French on short-haul flights in 2016
+  titre.lock: Distance totale parcourue par les Français sur des vols
+    court-courrier en 2016
+transport . avion . court courrier . passager km moyen:
+  description: |
+    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French.
+    We use an air traffic growth factor to update the 2016 data available to us.
+  description.lock: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français.
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+  titre: Average distance travelled by a French person on short-haul flights
+  titre.lock: Distance moyenne parcourue un Français sur des vols court-courrier
 transport . avion . court courrier . vitesse moyenne:
   note: |
     We use the average flight speed for a Paris-Toulouse flight.
@@ -17117,9 +17156,39 @@ transport . avion . court courrier . vitesse moyenne:
     Nous utilisons la vitesse moyenne de vol pour un Paris Toulouse.
   titre: average speed
   titre.lock: vitesse moyenne
+transport . avion . croissance 2016 2019:
+  description: |
+    2019 can be considered as a year of "normal" pre-covid traffic, 2022 tends moreover towards the traffic of 2019. The CWW website in January 2023 stated:
+
+    <img width="669" alt="image" src="https://user-images.githubusercontent.com/55186402/212965255-0d614dfe-74da-4e19-bb5c-0f168b04e6be.png">
+  description.lock: |
+    2019 peut-être considérée comme une année de trafic "normal" pré-covid, 2022 tend par ailleurs vers le trafic de 2019. On pouvait lire sur le site du MTE en janvier 2023 :
+
+    <img width="669" alt="image" src="https://user-images.githubusercontent.com/55186402/212965255-0d614dfe-74da-4e19-bb5c-0f168b04e6be.png">
+  note: |
+    To obtain this growth factor, we work on the traffic data of commercial flights transiting through the French airports according to the <a href="https://www.ecologie.gouv.fr/statistiques-du-trafic-aerien">MTE figures</a>):
+
+    2016:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965605-52c5013e-039e-4ff6-821a-015d9229f555.png">
+
+    2019:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965653-1adac292-2a68-4726-827d-3fee114b6a77.png">
+  note.lock: |
+    Pour obtenir ce facteur de croissance, nous travaillons sur les données du trafic des vols commerciaux transitants par la aéroports français ([d'après les chiffres du MTE](https://www.ecologie.gouv.fr/statistiques-du-trafic-aerien)) :
+
+    2016:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965605-52c5013e-039e-4ff6-821a-015d9229f555.png">
+
+    2019:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965653-1adac292-2a68-4726-827d-3fee114b6a77.png">
+  titre: Growth factor for French air traffic
+  titre.lock: Facteur de croissance du trafic aérien français
 transport . avion . long courrier:
   titre: long distance
   titre.lock: long courrier
+transport . avion . long courrier . durée moyennne:
+  titre: Average time spent by a French person on long-haul flights
+  titre.lock: Durée moyenne passée par un Français dans les vols long-courrier
 transport . avion . long courrier . empreinte par km:
   description: |
     We use the emission factor from the carone base
@@ -17150,8 +17219,16 @@ transport . avion . long courrier . heures de vol:
 
     💡 Ne comptez que les km de déplacement personnel et de déplacement domicile travail pour rejoindre votre lieu de travail habituel.
     Par exemple, si vous êtes en mission professionnelle dans un autre pays, cela rentre dans la comptabilité de votre entreprise.
-  question: How many hours a year do you travel beyond that on long-haul flights?
-  question.lock: Combien d'heures par an voyagez-vous au-delà en vol long courrier ?
+  note: The characterization "long haul" by the travel time is given by the rule
+    `medium haul . max duration` = 6.48h.
+  note.lock:
+    La caractérisation "long courrier" par le temps de trajet est donnée
+    par la règle `moyen courrier . durée max` = 6.48h.
+  question:
+    How many hours per year do you travel by plane for medium-haul flights
+    (more than 6 hours)?
+  question.lock: Combien d'heures par an voyagez-vous en avion pour des vols
+    moyen-courrier (plus 6h) ?
   suggestions:
     - 🚫✈️
     - Paris🔁Kinshasa
@@ -17168,6 +17245,24 @@ transport . avion . long courrier . heures de vol:
     - Paris🔁Sydney
   titre: flight hours
   titre.lock: heures de vol
+transport . avion . long courrier . km moyen:
+  description: |
+    2016 data from this CWW <a href="https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf">document</a>, including this table: 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  description.lock: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  titre: Total distance traveled by the French on long-haul flights in 2016
+  titre.lock: Distance totale parcourue par les Français sur des vols long-courrier en 2016
+transport . avion . long courrier . passager km moyen:
+  description: |
+    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French. 
+    We use an air traffic growth factor to update the 2016 data available to us.
+  description.lock: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+  titre: Average distance travelled by a French person on long-haul flights
+  titre.lock: Distance moyenne parcourue un Français sur des vols long-courrier
 transport . avion . long courrier . vitesse moyenne:
   note: |
     We use the average flight speed of the MicMac v2.6 model, determined from [this data](http://www.abm.fr/voyager-en-avion-le-guide-du-passager/en-complement/distances-et-durees-de-vol.html).
@@ -17178,6 +17273,18 @@ transport . avion . long courrier . vitesse moyenne:
 transport . avion . moyen courrier:
   titre: medium-haul
   titre.lock: moyen courrier
+transport . avion . moyen courrier . durée max:
+  description: Distance characterizing a medium-haul flight based on <a
+    href="https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530">this
+    discussion</a> in the Base Carbone forum.
+  description.lock: Distance caractérisant un vol moyen-courrier basé sur [cette
+    discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du
+    forum Base Carbone.
+  titre: Medium-haul travel time
+  titre.lock: Durée trajet moyen courrier
+transport . avion . moyen courrier . durée moyennne:
+  titre: Average time spent by a French person on medium-haul flights
+  titre.lock: Durée moyenne passée par un Français dans les vols moyen-courrier
 transport . avion . moyen courrier . empreinte par km:
   description: |
     We use the emission factor from the Carbon Baseline
@@ -17205,11 +17312,19 @@ transport . avion . moyen courrier . heures de vol:
 
     💡 Ne comptez que les km de déplacement personnel et de déplacement domicile travail pour rejoindre votre lieu de travail habituel.
     Par exemple, si vous êtes en mission professionnelle dans un autre pays, cela rentre dans la comptabilité de votre entreprise.
-  question: How many hours per year do you travel by plane to Europe or the
-    Mediterranean basin?
-  question.lock:
-    Combien d'heures par an voyagez-vous en avion vers l'Europe ou le
-    bassin méditerranéen ?
+  note:
+    The characterization "medium haul" by the travel time is given by the rule
+    `short haul . max duration` = 2.17h and `medium haul . max duration` =
+    6.48h.
+  note.lock:
+    La caractérisation "moyen courrier" par le temps de trajet est donnée
+    par la règle `court courrier . durée max`=2.17h et `moyen courrier . durée
+    max` = 6.48h.
+  question:
+    How many hours per year do you travel by plane for medium-haul flights
+    (between 2 and 6 hours)?
+  question.lock: Combien d'heures par an voyagez-vous en avion pour des vols
+    moyen-courrier (trajet entre 2h et 6h) ?
   suggestions:
     - 🚫✈️
     - Paris🔁Copenhagen
@@ -17224,6 +17339,25 @@ transport . avion . moyen courrier . heures de vol:
     - Paris🔁Liban
   titre: flight hours
   titre.lock: heures de vol
+transport . avion . moyen courrier . km moyen:
+  description: |
+    2016 data from this CWW <a href="https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf">document</a>, including this table: 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  description.lock: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+  titre: Total distance traveled by the French on medium-haul flights in 2016
+  titre.lock: Distance totale parcourue par les Français sur des vols
+    moyen-courrier en 2016
+transport . avion . moyen courrier . passager km moyen:
+  description: |
+    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French. 
+    We use an air traffic growth factor to update the 2016 data available to us.
+  description.lock: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+  titre: Average distance travelled by a French person on medium-haul flights
+  titre.lock: Distance moyenne parcourue un Français sur des vols moyen-courrier
 transport . avion . moyen courrier . vitesse moyenne:
   note: |
     We use the average flight speed for a Paris Algiers flight.
@@ -17233,21 +17367,17 @@ transport . avion . moyen courrier . vitesse moyenne:
   titre.lock: vitesse moyenne
 transport . avion . usager:
   description: |
-    If you don't fly every year but plan to continue to do so, answer "yes"
-    and roughly estimate the number of hours you fly per year.
+    If you don't fly every year but plan to continue to do so, answer "yes" and roughly estimate the number of hours you fly per year.
 
-    This is not very rigorous, but flying has such a large footprint on the
-    climate that it is important to take this into account.
+    This is not very rigorous, but flying has such a large footprint on the climate that it is important to take this into account.
 
-    > For example, if you took a 20-hour long-haul flight in 2018 and plan
-    > to take it again in 2022, we can assume that you take it every 4 years
-    > or so: just enter `5 hours` in the "long-haul" question.
+    > For example, if you took a long-haul flight of 20 hours in 2018 and you plan to take it again in 2022, we can assume that you take it every 4 years or so: just enter `5 hours` in the question "long-haul".
   description.lock: |
     Si vous ne prenez pas l'avion tous les ans mais que vous comptez continuer à le prendre, répondez "oui" et estimez grossièrement le nombre d'heures de vol ramené à l'année.
 
     Ce n'est pas très rigoureux, mais l'avion a une telle empreinte sur le climat qu'il est important de prendre cela en compte.
 
-    > Par exemple, si vous avez pris un long-courrier de 20h en 2018 et que vous comptez le reprendre en 2022, nous pouvons partir du principe que vous le prenez tous les 4 ans environ : renseignez simplement `5 heures` à la question "long-courier".
+    > Par exemple, si vous avez pris un long-courrier de 20h en 2018 et que vous comptez le reprendre en 2022, nous pouvons partir du principe que vous le prenez tous les 4 ans environ : renseignez simplement `5 heures` à la question "long-courrier".
   question: Do you fly?
   question.lock: Prenez-vous l'avion ?
   titre: user

--- a/data/translated-rules-en-us.yaml
+++ b/data/translated-rules-en-us.yaml
@@ -17096,7 +17096,7 @@ transport . avion . court courrier . heures de vol:
     💡 Only count personal travel and commuting miles to your usual place of work.
     For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passées dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
@@ -17139,11 +17139,11 @@ transport . avion . court courrier . km moyen:
     court-courrier en 2016
 transport . avion . court courrier . passager km moyen:
   description: |
-    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French.
-    We use an air traffic growth factor to update the 2016 data available to us.
+    We work on the average long-distance mobility data of the French to obtain an average value for the air travel habits of the French.
+    We use an air traffic growth factor to update the 2016 data we have.
   description.lock: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français.
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français.
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
   titre: Average distance travelled by a French person on short-haul flights
   titre.lock: Distance moyenne parcourue un Français sur des vols court-courrier
 transport . avion . court courrier . vitesse moyenne:
@@ -17205,7 +17205,7 @@ transport . avion . long courrier . heures de vol:
     💡 Only count personal travel and commuting miles to your usual place of work.
     For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
+    Comptez les heures que vous avez passées dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
 
     A noter que si vous avez voyagez vers une destination lointaine en plusieurs trajets "courts", ils sont à prendre en compte dans les questions précédentes.
 
@@ -17249,11 +17249,11 @@ transport . avion . long courrier . km moyen:
   titre.lock: Distance totale parcourue par les Français sur des vols long-courrier en 2016
 transport . avion . long courrier . passager km moyen:
   description: |
-    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French. 
-    We use an air traffic growth factor to update the 2016 data available to us.
+    We work on the average long-distance mobility data of the French to obtain an average value for the air travel habits of the French. 
+    We use an air traffic growth factor to update the 2016 data we have.
   description.lock: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
   titre: Average distance travelled by a French person on long-haul flights
   titre.lock: Distance moyenne parcourue un Français sur des vols long-courrier
 transport . avion . long courrier . vitesse moyenne:
@@ -17295,7 +17295,7 @@ transport . avion . moyen courrier . heures de vol:
     💡 Only count personal travel and commuting miles to your usual place of work.
     For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passées dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 
@@ -17340,11 +17340,11 @@ transport . avion . moyen courrier . km moyen:
     moyen-courrier en 2016
 transport . avion . moyen courrier . passager km moyen:
   description: |
-    We work on the average data of the long distance mobility of the French to obtain an average value concerning the air travel habits of the French. 
-    We use an air traffic growth factor to update the 2016 data available to us.
+    We work on the average long-distance mobility data of the French to obtain an average value for the air travel habits of the French. 
+    We use an air traffic growth factor to update the 2016 data we have.
   description.lock: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
   titre: Average distance travelled by a French person on medium-haul flights
   titre.lock: Distance moyenne parcourue un Français sur des vols moyen-courrier
 transport . avion . moyen courrier . vitesse moyenne:

--- a/data/translated-rules-en-us.yaml
+++ b/data/translated-rules-en-us.yaml
@@ -17088,18 +17088,15 @@ transport . avion . court courrier . empreinte par km:
   titre.lock: empreinte par km
 transport . avion . court courrier . heures de vol:
   description: |
-    Count the number of hours you spent in an airplane for flights of less
-    than 1000km (give or take). If you have stopovers, simply add up the
-    times of each flight.
+    Count the hours you spent on a plane for trips of less than 2 hours (which corresponds to flights of less than about 1000km). If you have stopovers, simply add up the times of each flight.
 
-    Suggestions are based on the minimum rounded flight time found in search
-    engines, doubled to consider a round trip.
 
-    💡 Only count personal travel and commuting miles to your usual place of
-    work. For example, if you are on a work assignment in another country,
-    this fits into your company's accounting.
+    The suggestions are based on the minimum round trip flight time found in search engines, doubled to consider a round trip.
+
+    💡 Only count personal travel and commuting miles to your usual place of work.
+    For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance inférieure à 1000km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passé dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
@@ -17199,21 +17196,18 @@ transport . avion . long courrier . empreinte par km:
   titre.lock: empreinte par km
 transport . avion . long courrier . heures de vol:
   description: |
-    Count the hours you spent in an airplane for flights longer than 3500km,
-    i.e. beyond Europe and the Mediterranean.
+    Count the hours you spent in an airplane for trips longer than 6 hours (which corresponds to flights of more than about 3500km). If you have stopovers, simply add up the times of each flight. 
 
-    If you have stopovers, simply add up the times of each flight.
+    Note that if you have traveled to a distant destination in several "short" trips, they are to be taken into account in the previous questions.
 
-    Suggestions are based on the minimum rounded flight time found in search
-    engines, doubled to consider a round trip.
+    The suggestions are based on the minimum round trip flight time found in the search engines, doubled to consider a round trip.
 
-    💡 Only count personal travel and commuting miles to your usual place of
-    work. For example, if you are on a work assignment in another country,
-    this fits into your company's accounting.
+    💡 Only count personal travel and commuting miles to your usual place of work.
+    For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance supérieure à 3500km, c'est-à-dire au-delà de l'Europe et du pourtour méditerranéen.
+    Comptez les heures que vous avez passé dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
 
-    Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    A noter que si vous avez voyagez vers une destination lointaine en plusieurs trajets "courts", ils sont à prendre en compte dans les questions précédentes.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 
@@ -17294,18 +17288,14 @@ transport . avion . moyen courrier . empreinte par km:
   titre.lock: empreinte par km
 transport . avion . moyen courrier . heures de vol:
   description: |
-    Count the hours you spent in an airplane for flights between 1000km and
-    3500km (roughly). If you have stopovers, simply add up the times of each
-    flight.
+    Count the hours you spent in an airplane for trips between 2 hours and 6 hours (which corresponds to flights between 1000km and 3500km approximately). If you have stopovers, simply add up the times of each flight.
 
-    Suggestions are based on the minimum rounded flight time found in search
-    engines, doubled to consider a round trip.
+    The suggestions are based on the minimum round trip flight time found in search engines, doubled to consider a round trip.
 
-    💡 Only count personal travel and commuting miles to your usual place of
-    work. For example, if you are on a work assignment in another country,
-    this fits into your company's accounting.
+    💡 Only count personal travel and commuting miles to your usual place of work.
+    For example, if you are on a work assignment in another country, this fits into your company's accounting.
   description.lock: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance entre 1000km et 3500km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passé dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 

--- a/data/translated-rules-en-us.yaml
+++ b/data/translated-rules-en-us.yaml
@@ -17224,11 +17224,10 @@ transport . avion . long courrier . heures de vol:
   note.lock:
     La caractérisation "long courrier" par le temps de trajet est donnée
     par la règle `moyen courrier . durée max` = 6.48h.
-  question:
-    How many hours per year do you travel by plane for medium-haul flights
+  question: How many hours per year do you travel by plane for long-haul flights
     (more than 6 hours)?
   question.lock: Combien d'heures par an voyagez-vous en avion pour des vols
-    moyen-courrier (plus 6h) ?
+    long-courrier (plus 6h) ?
   suggestions:
     - 🚫✈️
     - Paris🔁Kinshasa

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -71,8 +71,8 @@ transport . avion . court courrier . passager km moyen:
   formule: km moyen * croissance 2016 2019 / population
   unité: km
   description: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français.
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français.
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
 transport . avion . court courrier . durée moyennne:
   titre: Durée moyenne passée par un Français dans les vols court-courrier
   formule: passager km moyen / vitesse moyenne
@@ -81,7 +81,7 @@ transport . avion . court courrier . durée moyennne:
 transport . avion . court courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (trajet de moins de 2h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passées dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
@@ -128,8 +128,8 @@ transport . avion . moyen courrier . passager km moyen:
   formule: km moyen * croissance 2016 2019 / population
   unité: km
   description: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
 transport . avion . moyen courrier . durée moyennne:
   titre: Durée moyenne passée par un Français dans les vols moyen-courrier
   formule: passager km moyen / vitesse moyenne
@@ -138,7 +138,7 @@ transport . avion . moyen courrier . durée moyennne:
 transport . avion . moyen courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (trajet entre 2h et 6h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passées dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 
@@ -180,8 +180,8 @@ transport . avion . long courrier . passager km moyen:
   formule: km moyen * croissance 2016 2019 / population
   unité: km
   description: |
-    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
-    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des Français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disposons.
 transport . avion . long courrier . durée moyennne:
   titre: Durée moyenne passée par un Français dans les vols long-courrier
   formule: passager km moyen / vitesse moyenne
@@ -190,7 +190,7 @@ transport . avion . long courrier . durée moyennne:
 transport . avion . long courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols long-courrier (plus 6h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
+    Comptez les heures que vous avez passées dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
 
     A noter que si vous avez voyagez vers une destination lointaine en plusieurs trajets "courts", ils sont à prendre en compte dans les questions précédentes.
 

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -9,6 +9,8 @@ transport . avion:
 
     Gardons aussi en tête que le Français moyen ne prend pas ou peu l'avion. L'essentiel de l'empreinte de l'aviation est donc concentrée sur 10% ou moins des Français.
 
+    > Pour la définition des gammes de vol, de court-courrier à long-courrier, nous utilisons [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
+
   note: |
     Nous avons fait le choix de demander le total d'heures de vol, plutôt que de demander à l'utilisateur de renseigner chacun de ses vols
     via l'aéroport de départ, d'arrivée et la classe économique. C'est une évolution possible par la suite,
@@ -54,7 +56,9 @@ transport . avion . court courrier . empreinte par km:
   unité: kgCO2e/km
 
 transport . avion . court courrier . heures de vol:
-  question: Combien d'heures par an voyagez-vous en avion en France métropolitaine ?
+  question:
+    texte: >
+      Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (de moins de {{1000 / vitesse moyenne}}) ?
   description: |
     Comptez les heures que vous avez passé dans un avion pour des vols d'une distance inférieure à 1000km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -39,7 +39,7 @@ transport . avion . usager:
 
     Ce n'est pas très rigoureux, mais l'avion a une telle empreinte sur le climat qu'il est important de prendre cela en compte.
 
-    > Par exemple, si vous avez pris un long-courrier de 20h en 2018 et que vous comptez le reprendre en 2022, nous pouvons partir du principe que vous le prenez tous les 4 ans environ : renseignez simplement `5 heures` à la question "long-courier".
+    > Par exemple, si vous avez pris un long-courrier de 20h en 2018 et que vous comptez le reprendre en 2022, nous pouvons partir du principe que vous le prenez tous les 4 ans environ : renseignez simplement `5 heures` à la question "long-courrier".
   par défaut: oui
 
 transport . avion . court courrier:
@@ -57,14 +57,26 @@ transport . avion . court courrier . empreinte par km:
 transport . avion . court courrier . durée max:
   titre: Durée trajet court courrier
   arrondi: oui
-  formule: 1000km / vitesse moyenne
+  formule: 1000 km / vitesse moyenne
   description: Distance caractérisant un vol court-courrier basé sur [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
-transport . avion . court courrier . court courrier . km moyen:
+transport . avion . court courrier . km moyen:
+  titre: Distance totale parcourue par les Français sur des vols court-courrier en 2016
   formule: 2700000000
   unité: km
   description: |
     Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
-<img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+transport . avion . court courrier . passager km moyen:
+  titre: Distance moyenne parcourue un Français sur des vols court-courrier
+  formule: km moyen * croissance 2016 2019 / population
+  unité: km
+  description: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français.
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+transport . avion . court courrier . durée moyennne:
+  titre: Durée moyenne passée par un Français dans les vols court-courrier
+  formule: passager km moyen / vitesse moyenne
+  unité: h
 
 transport . avion . court courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (trajet de moins de 2h) ?
@@ -84,13 +96,13 @@ transport . avion . court courrier . heures de vol:
     Paris🔁Nice: 2.8
     Paris🔁Ajaccio: 3.2
   unité: h/an
-  par défaut: 1 h/an
+  par défaut: durée moyennne
   note: La caractérisation "court courrier" par le temps de trajet est donnée par la règle `court courrier . durée max` = 2.17h.
 
 transport . avion . moyen courrier:
   formule: heures de vol * vitesse moyenne * empreinte par km
 transport . avion . moyen courrier . vitesse moyenne:
-  formule: 1350 / 2.5
+  formule: 1350 km / 2.5 h
   unité: km/h
   note: |
     Nous utilisons la vitesse moyenne de vol pour un Paris Alger.
@@ -102,8 +114,26 @@ transport . avion . moyen courrier . empreinte par km:
 transport . avion . moyen courrier . durée max:
   titre: Durée trajet moyen courrier
   arrondi: oui
-  formule: 3500km / vitesse moyenne
+  formule: 3500 km / vitesse moyenne
   description: Distance caractérisant un vol moyen-courrier basé sur [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
+transport . avion . moyen courrier . km moyen:
+  titre: Distance totale parcourue par les Français sur des vols moyen-courrier en 2016
+  formule: 8400000000
+  unité: km
+  description: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+transport . avion . moyen courrier . passager km moyen:
+  titre: Distance moyenne parcourue un Français sur des vols moyen-courrier
+  formule: km moyen * croissance 2016 2019 / population
+  unité: km
+  description: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+transport . avion . moyen courrier . durée moyennne:
+  titre: Durée moyenne passée par un Français dans les vols moyen-courrier
+  formule: passager km moyen / vitesse moyenne
+  unité: h
 
 transport . avion . moyen courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (trajet entre 2h et 6h) ?
@@ -123,7 +153,7 @@ transport . avion . moyen courrier . heures de vol:
     Paris🔁Liban: 8
 
   unité: h/an
-  par défaut: 1 h/an
+  par défaut: durée moyennne
   note: La caractérisation "moyen courrier" par le temps de trajet est donnée par la règle `court courrier . durée max`=2.17h et `moyen courrier . durée max` = 6.48h.
 
 transport . avion . long courrier:
@@ -138,6 +168,24 @@ transport . avion . long courrier . empreinte par km:
   description: |
     Nous utilisons le facteur d'émission de la base carone `Avion passagers - Long courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
+transport . avion . long courrier . km moyen:
+  titre: Distance totale parcourue par les Français sur des vols long-courrier en 2016
+  formule: 101800000000
+  unité: km
+  description: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+    <img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
+transport . avion . long courrier . passager km moyen:
+  titre: Distance moyenne parcourue un Français sur des vols long-courrier
+  formule: km moyen * croissance 2016 2019 / population
+  unité: km
+  description: |
+    On travaille sur les données moyennes de la mobilité longue distance des Français pour obtenir une valeur moyenne concernant les habitudes de voyages en avion des français. 
+    Nous utilisons un facteur de croissance du trafic aérien pour mettre à jour les données de 2016 dont nous disponsons.
+transport . avion . long courrier . durée moyennne:
+  titre: Durée moyenne passée par un Français dans les vols long-courrier
+  formule: passager km moyen / vitesse moyenne
+  unité: h
 
 transport . avion . long courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (plus 6h) ?
@@ -160,5 +208,22 @@ transport . avion . long courrier . heures de vol:
     Paris🔁Sydney: 40
 
   unité: h/an
-  par défaut: 1 h/an
+  par défaut: durée moyennne
   note: La caractérisation "long courrier" par le temps de trajet est donnée par la règle `moyen courrier . durée max` = 6.48h.
+
+transport . avion . croissance 2016 2019:
+  titre: Facteur de croissance du trafic aérien français
+  formule: 420.45 / 355.19
+  note: |
+    Pour obtenir ce facteur de croissance, nous travaillons sur les données du trafic des vols commerciaux transitants par la aéroports français ([d'après les chiffres du MTE](https://www.ecologie.gouv.fr/statistiques-du-trafic-aerien)) :
+
+    2016:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965605-52c5013e-039e-4ff6-821a-015d9229f555.png">
+
+    2019:
+    <img width="700" alt="image" src="https://user-images.githubusercontent.com/55186402/212965653-1adac292-2a68-4726-827d-3fee114b6a77.png">
+
+  description: |
+    2019 peut-être considérée comme une année de trafic "normal" pré-covid, 2022 tend par ailleurs vers le trafic de 2019. On pouvait lire sur le site du MTE en janvier 2023 :
+
+    <img width="669" alt="image" src="https://user-images.githubusercontent.com/55186402/212965255-0d614dfe-74da-4e19-bb5c-0f168b04e6be.png">

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -81,7 +81,7 @@ transport . avion . court courrier . durée moyennne:
 transport . avion . court courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (trajet de moins de 2h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance inférieure à 1000km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passé dans un avion pour des trajets de moins de 2h (ce qui correspond à des vols d'une distance inférieure à 1000km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
@@ -138,7 +138,7 @@ transport . avion . moyen courrier . durée moyennne:
 transport . avion . moyen courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (trajet entre 2h et 6h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance entre 1000km et 3500km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    Comptez les heures que vous avez passé dans un avion pour des trajets entre 2h et 6h (ce qui correspond à des vols d'une distance comprise entre 1000km et 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 
@@ -190,9 +190,9 @@ transport . avion . long courrier . durée moyennne:
 transport . avion . long courrier . heures de vol:
   question: Combien d'heures par an voyagez-vous en avion pour des vols long-courrier (plus 6h) ?
   description: |
-    Comptez les heures que vous avez passé dans un avion pour des vols d'une distance supérieure à 3500km, c'est-à-dire au-delà de l'Europe et du pourtour méditerranéen.
+    Comptez les heures que vous avez passé dans un avion pour des trajets de plus de 6h (ce qui correspond à des vols d'une distance supérieure à 3500km environ). Si vous faites des escales, additionnez simplement les durées de chaque vol. 
 
-    Si vous faites des escales, additionnez simplement les durées de chaque vol.
+    A noter que si vous avez voyagez vers une destination lointaine en plusieurs trajets "courts", ils sont à prendre en compte dans les questions précédentes.
 
     Les suggestions sont basées sur la durée minimum arrondie de vol constatée dans les moteurs de recherche, doublée pour considérer un aller-retour.
 

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -54,11 +54,20 @@ transport . avion . court courrier . empreinte par km:
   description: |
     Nous utilisons le facteur d'émission de la base carbone `Avion passagers - Court courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
+transport . avion . court courrier . durée max:
+  titre: Durée trajet court courrier
+  arrondi: oui
+  formule: 1000km / vitesse moyenne
+  description: Distance caractérisant un vol court-courrier basé sur [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
+transport . avion . court courrier . court courrier . km moyen:
+  formule: 2700000000
+  unité: km
+  description: |
+    Données 2016 issues de ce [document](https://www.statistiques.developpement-durable.gouv.fr/sites/default/files/2018-11/datalab-essentiel-138-mobilite-longue-distance-2016-fevrier2018.pdf) du MTE, notamment ce tableau : 
+<img width="650" alt="image" src="https://user-images.githubusercontent.com/55186402/212713769-96dce8f6-c5f4-4ae5-8456-8764adb2d84d.png">
 
 transport . avion . court courrier . heures de vol:
-  question:
-    texte: >
-      Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (de moins de {{1000 / vitesse moyenne}}) ?
+  question: Combien d'heures par an voyagez-vous en avion pour des vols court-courrier (trajet de moins de 2h) ?
   description: |
     Comptez les heures que vous avez passé dans un avion pour des vols d'une distance inférieure à 1000km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
@@ -74,9 +83,9 @@ transport . avion . court courrier . heures de vol:
     Paris🔁Toulouse: 2.6
     Paris🔁Nice: 2.8
     Paris🔁Ajaccio: 3.2
-
   unité: h/an
   par défaut: 1 h/an
+  note: La caractérisation "court courrier" par le temps de trajet est donnée par la règle `court courrier . durée max` = 2.17h.
 
 transport . avion . moyen courrier:
   formule: heures de vol * vitesse moyenne * empreinte par km
@@ -90,9 +99,14 @@ transport . avion . moyen courrier . empreinte par km:
   description: |
     Nous utilisons le facteur d'émission de la base carbone `Avion passagers - Moyen courrier, 2018 - AVEC trainées`.
   unité: kgCO2e/km
+transport . avion . moyen courrier . durée max:
+  titre: Durée trajet moyen courrier
+  arrondi: oui
+  formule: 3500km / vitesse moyenne
+  description: Distance caractérisant un vol moyen-courrier basé sur [cette discussion](https://bilans-ges.ademe.fr/forum/viewtopic.php?t=4192#p5530) du forum Base Carbone.
 
 transport . avion . moyen courrier . heures de vol:
-  question: Combien d'heures par an voyagez-vous en avion vers l'Europe ou le bassin méditerranéen ?
+  question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (trajet entre 2h et 6h) ?
   description: |
     Comptez les heures que vous avez passé dans un avion pour des vols d'une distance entre 1000km et 3500km (à peu près). Si vous faites des escales, additionnez simplement les durées de chaque vol.
 
@@ -110,6 +124,7 @@ transport . avion . moyen courrier . heures de vol:
 
   unité: h/an
   par défaut: 1 h/an
+  note: La caractérisation "moyen courrier" par le temps de trajet est donnée par la règle `court courrier . durée max`=2.17h et `moyen courrier . durée max` = 6.48h.
 
 transport . avion . long courrier:
   formule: heures de vol * vitesse moyenne * empreinte par km
@@ -125,7 +140,7 @@ transport . avion . long courrier . empreinte par km:
   unité: kgCO2e/km
 
 transport . avion . long courrier . heures de vol:
-  question: Combien d'heures par an voyagez-vous au-delà en vol long courrier ?
+  question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (plus 6h) ?
   description: |
     Comptez les heures que vous avez passé dans un avion pour des vols d'une distance supérieure à 3500km, c'est-à-dire au-delà de l'Europe et du pourtour méditerranéen.
 
@@ -146,3 +161,4 @@ transport . avion . long courrier . heures de vol:
 
   unité: h/an
   par défaut: 1 h/an
+  note: La caractérisation "long courrier" par le temps de trajet est donnée par la règle `moyen courrier . durée max` = 6.48h.

--- a/data/transport/transport . avion.yaml
+++ b/data/transport/transport . avion.yaml
@@ -188,7 +188,7 @@ transport . avion . long courrier . durée moyennne:
   unité: h
 
 transport . avion . long courrier . heures de vol:
-  question: Combien d'heures par an voyagez-vous en avion pour des vols moyen-courrier (plus 6h) ?
+  question: Combien d'heures par an voyagez-vous en avion pour des vols long-courrier (plus 6h) ?
   description: |
     Comptez les heures que vous avez passé dans un avion pour des vols d'une distance supérieure à 3500km, c'est-à-dire au-delà de l'Europe et du pourtour méditerranéen.
 


### PR DESCRIPTION
En travaillant sur l'i18n, la question avion est une des seules spécifique à la France. 

On s'est rendu compte qu'il serait mieux de raisonner en vols de moins de x heures plutôt que de décrire des zones géographiques, à la fois pour l'i18n et pour l'UX. 

De plus, nos définitions des distances semblent remises en question. 

- [x] Réécriture des questions sur l'avion pour les généraliser
- [x] Nouvelles valeurs par défaut basées sur des statistiques