### PR TITLE
[I18N] Nouvelles régions supportées dans NGC

### DIFF
--- a/data/i18n/models/CA-en-us.yaml
+++ b/data/i18n/models/CA-en-us.yaml
@@ -1,0 +1,5 @@
+intensité électricité:
+  titre: Climate intensity of the canadian electricity mix (Quebec)
+  formule: 0.028
+  note: |
+    [Electricity Map](https://app.electricitymaps.com/zone/CA-QC), 2022

--- a/data/i18n/models/CA.yaml
+++ b/data/i18n/models/CA.yaml
@@ -1,0 +1,10 @@
+params:
+  nom: Canada
+  code: CA
+  gentilé: canadienne
+
+intensité électricité:
+  titre: Intensité climat du mix électrique canadien (région Québec)
+  formule: 0.028
+  note: |
+    [Electricity Map](https://app.electricitymaps.com/zone/CA-QC), 2022, vision 5 ans, 2022


### PR DESCRIPTION
- Fix #1717

L'idée est de répondre à un besoin de déploiement de notre version multi-modèle de NGC en ajoutant de nouvelles régions :

- [ ] 🇨🇦 Canada (attention grand pays avec mix électriques non homogène -> plusieurs régions ? Un peu de dev à prévoir..)
- [ ] 🇵🇹 Portugal
- [ ] 🇬🇧 UK
- [ ] 🇧🇪 Belgique
- [ ] 🇮🇹 Italie
- [ ] 🇩🇪 Allemagne
- [ ] 🇵🇱 Pologne
- [ ] 🇱🇺 Luxembourg
- [ ] 🇹🇷 Turquie
- [ ] 🏝️ Autres régions d’Outre-mer

En parallèle, un travail peut-être fait côté site (cf tâches de #1717 et le bug https://github.com/datagir/nosgestesclimat-site/issues/846)