### PR TITLE
Feat(scripts/i18n): add v0 translation scripts for region models

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="https://nosgestesclimat.fr/images/petit-logo@2x.png" alt="Nos Gestes Climat logo" width="70" height="70">
   <h2 align="center">
-    Wiki of the Nos Gestes Climat (NGC) <a href="https://nosgestesclimat.fr">website</a>
+    Wiki of the Nos Gestes Climat (NGC) model 
   </h2>
 
   <div align="center">

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -18,6 +18,8 @@
      - [Modification of the `./data` files](https://github.com/datagir/nosgestesclimat/wiki/Translation#modification-of-the-data-files)
      - [Modification of the `./personas` files](https://github.com/datagir/nosgestesclimat/wiki/Translation#modification-of-the-personas-files)
      - [Improving an existing translation](https://github.com/datagir/nosgestesclimat/wiki/Translation#improving-an-existing-translation)
+     - [Adding a new language](https://github.com/datagir/nosgestesclimat/wiki/Translation#adding-a-new-language)
+     - [Translating region models](https://github.com/datagir/nosgestesclimat/wiki/Translation#translating-region-models)
    - [Architecture](https://github.com/datagir/nosgestesclimat/wiki/Translation#architecture)
    - [Available scripts](https://github.com/datagir/nosgestesclimat/wiki/Translation#available-scripts)
 5. [**Other**](https://github.com/datagir/nosgestesclimat/wiki/Other)

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -20,6 +20,7 @@
   * [Modification of the `./personas` files](#modification-of-the-personas-files)
   * [Improving an existing translation](#improving-an-existing-translation)
     * [Contribution guide for translation from GitHub](#contribution-guide-for-translation-from-github)
+  * [Translating region models](#translating-region-models)
 * [Available scripts](#available-scripts)
   * [`translate-rules.js`](#translate-rulesjs)
   * [`check-translation.js`](#check-translationjs)
@@ -27,6 +28,7 @@
   * [`translate-personas.js`](#translate-personasjs)
   * [`personasToJSON.js`](#personastojsonjs)
   * [`check-personas.js`](#check-personasjs)
+  * [`translateRegionModel.js`](#translateregionmodeljs)
 
 <!-- vim-markdown-toc -->
 
@@ -154,6 +156,12 @@ simply send your suggestion in a mail to: datagir@ademe.fr.
 Well done! We will look at your proposition before [updating the
 translations](#updating-the-translation) and integrating the changes to the
 project.
+
+### Translating region models
+
+To translate region models stored in `./data/i18n/models` from a language to an
+other, you can use the [`translateRegionModel.js`](#translateregionmodeljs)
+script.
 
 ## Available scripts
 
@@ -296,3 +304,19 @@ This script allows to get missing personas translations.
 >   ```
 >   yarn check:personas -h
 >   ```
+
+### `translateRegionModel.js`
+
+This script allows to translate region models stored in `./data/i18n/models`.
+
+You can specify following flag:
+
+- `--source` (`-s`) to choose the language translate from.
+- `--target` (`-t`) to choose the language(s) translate to.
+- `--model` (`-o`) to choose region code corresponding to the model to translate.
+
+> To run with `yarn`:
+>
+> ```
+> yarn translate:model [options]
+> ```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"translate:personas": "node scripts/i18n/translate-personas.js",
 		"check:rules": "node scripts/i18n/check-translation.js",
 		"translate:rules": "node scripts/i18n/translate-rules.js",
-		"generate:servicesRules": "node scripts/services-societaux/analyze_naf_ca.js && node scripts/services-societaux/desagregate_naf_SDES.js && node scripts/services-societaux/generate_rules.js"
+		"generate:servicesRules": "node scripts/services-societaux/analyze_naf_ca.js && node scripts/services-societaux/desagregate_naf_SDES.js && node scripts/services-societaux/generate_rules.js",
+		"translate:model": "node scripts/i18n/translateRegionModel.js"
 	},
 	"repository": {
 		"type": "git",
@@ -46,6 +47,7 @@
 		"deepl-node": "^1.7.0",
 		"dotenv": "^16.0.3",
 		"isomorphic-fetch": "^3.0.0",
+		"prompt-sync": "^4.2.0",
 		"ramda": "^0.28.0",
 		"yargs": "^17.6.0"
 	}

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -122,7 +122,8 @@ const getArgs = (description, opts) => {
 			alias: 'o',
 			type: 'string',
 			array: true,
-			description: 'The region code model',
+			choices: regions.supportedRegionCodes,
+			description: 'The region code model.',
 		})
 	}
 	if (opts.markdown) {
@@ -143,23 +144,10 @@ const getArgs = (description, opts) => {
 	}
 
 	const destLangs = (argv.target ?? utils.availableLanguages).filter((l) => {
-		if (!utils.availableLanguages.includes(l)) {
-			printWarn(`SKIP: the language '${l}' is not supported.`)
-			return false
-		}
 		return l !== srcLang
 	})
 
-	const destRegions =
-		argv.model?.filter((r) => {
-			if (!regions.supportedRegionCodes.includes(r)) {
-				cli.printWarn(
-					`[WARN] - the region '${r}' is not supported, skipping it.`
-				)
-				return false
-			}
-			return true
-		}) ?? regions.supportedRegionCodes
+	const destRegions = argv.model ?? regions.supportedRegionCodes
 
 	const srcFile = argv.file ?? opts.defaultSrcFile
 

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -5,6 +5,7 @@
 const yargs = require('yargs')
 
 const utils = require('./utils')
+const regions = require('./regionCommons')
 
 const colors = {
 	reset: '\x1b[0m',
@@ -95,7 +96,9 @@ const getArgs = (description, opts) => {
 		args = args.option('file', {
 			alias: 'p',
 			type: 'string',
-			description: `The source file to translate from the 'locales/pages' directory. If not specified, all the files in 'locales/pages' will be translated.`,
+			description:
+				opts.file.description ??
+				`The source file to translate from the 'locales/pages' directory. If not specified, all the files in 'locales/pages' will be translated.`,
 		})
 	}
 	if (opts.remove) {
@@ -147,6 +150,17 @@ const getArgs = (description, opts) => {
 		return l !== srcLang
 	})
 
+	const destRegions =
+		argv.model?.filter((r) => {
+			if (!regions.supportedRegionCodes.includes(r)) {
+				cli.printWarn(
+					`[WARN] - the region '${r}' is not supported, skipping it.`
+				)
+				return false
+			}
+			return true
+		}) ?? regions.supportedRegionCodes
+
 	const srcFile = argv.file ?? opts.defaultSrcFile
 
 	return {
@@ -155,7 +169,7 @@ const getArgs = (description, opts) => {
 			!argv.target && opts.target === 'all'
 				? utils.availableLanguages
 				: destLangs,
-		destRegions: argv.model,
+		destRegions,
 		force: argv.force,
 		remove: argv.remove,
 		srcFile,

--- a/scripts/i18n/regionCommons.js
+++ b/scripts/i18n/regionCommons.js
@@ -1,0 +1,62 @@
+/// ---------------------- Retrieving the regions models ----------------------
+
+const path = require('path')
+const fs = require('fs')
+const { exit } = require('process')
+
+const { publicDir, readYAML } = require('./utils')
+
+const regionsModelsPath = path.resolve('data/i18n/models')
+const defaultModelCode = 'FR'
+const defaultRegionModelParam = {
+	[defaultModelCode]: {
+		nom: 'France métropolitaine',
+		gentilé: 'française',
+		code: defaultModelCode,
+	},
+}
+const supportedRegionPath = path.join(publicDir, `supportedRegions.json`)
+
+//
+// Reads all regions models and create a json file containing params of each region.
+//
+// Only XX-fr.yaml files are read in 'data/i18n/models' directory, their are the base models.
+// (XX-YY.yaml files are not read, they are the translation of the base models.)
+//
+// The default region and hardcoded one is FR.
+//
+const supportedRegions = fs
+	.readdirSync(regionsModelsPath)
+	.reduce((acc, filename) => {
+		if (!filename.match(/([A-Z]{2})-fr.yaml/)) return acc
+		try {
+			const regionPath = path.join(regionsModelsPath, filename)
+			const rules = readYAML(regionPath)
+			const params = rules['params']
+			if (params === undefined) {
+				console.log(
+					` ❌ The file ${filename} doesn't contain a 'params' key, aborting...`
+				)
+				exit(-1)
+			}
+			return { ...acc, [rules.params.code]: params }
+		} catch (err) {
+			console.log(
+				' ❌ An error occured while reading the file:',
+				filename,
+				':\n\n',
+				err.message
+			)
+			exit(-1)
+		}
+	}, defaultRegionModelParam)
+
+const supportedRegionCodes = Object.keys(supportedRegions)
+
+module.exports = {
+	supportedRegionPath,
+	supportedRegionCodes,
+	supportedRegions,
+	defaultModelCode,
+	regionsModelsPath,
+}

--- a/scripts/i18n/translateRegionModel.js
+++ b/scripts/i18n/translateRegionModel.js
@@ -1,0 +1,117 @@
+const path = require('path')
+const { existsSync } = require('fs')
+const prompt = require('prompt-sync')()
+
+const cli = require('./cli')
+const deepl = require('./deepl')
+const utils = require('./utils')
+
+const localizedRegionModelsDir = path.resolve('./data/i18n/models/')
+
+const { srcLang, destLangs, destRegions } = cli.getArgs(
+	`Translates localized region models stored in ${localizedRegionModelsDir}.`,
+	{
+		source: true,
+		target: true,
+		model: true,
+	}
+)
+
+// TODO: support multiple models
+const model = destRegions[0]
+
+const srcFile = path.join(localizedRegionModelsDir, `${model}-${srcLang}.yaml`)
+const srcModel = utils.readYAML(srcFile)
+
+// TODO: there is something to do with async/await here
+const translateRule = async ([ruleName, ruleVal], destLang) => {
+	const translate = async (str) => {
+		return await deepl.fetchTranslation(
+			str,
+			srcLang.toUpperCase(),
+			destLang.toUpperCase()
+		)
+	}
+	const translateMd = async (str) => {
+		return await deepl.fetchTranslationMarkdown(
+			str,
+			srcLang.toUpperCase(),
+			destLang.toUpperCase()
+		)
+	}
+	return [
+		ruleName,
+		Object.fromEntries(
+			await Promise.all(
+				Object.entries(ruleVal).map(async ([attr, val]) => {
+					if (utils.mechanismsToTranslate.includes(attr)) {
+						switch (attr) {
+							case 'suggestions': {
+								val = Object.fromEntries(
+									await Promise.all(
+										Object.entries(val).map(async ([key, val]) => {
+											const translatedKey = await translate(key)
+											return [translatedKey, val]
+										})
+									)
+								)
+								break
+							}
+							case 'mosaique': {
+								val = translateRule(val, destLang)
+								break
+							}
+							case 'description':
+							case 'note': {
+								val = translateMd(val)
+								break
+							}
+							default: {
+								val = translate(val)
+							}
+						}
+						val = await val
+					}
+					return [attr, val]
+				})
+			)
+		),
+	]
+}
+
+const translateModel = async (srcRules, destLang) => {
+	return Object.fromEntries(
+		await Promise.all(
+			Object.entries(srcRules).map(async (rule) => {
+				if (rule !== 'param') {
+					return await translateRule(rule, destLang)
+				} else {
+					return rule
+				}
+			})
+		)
+	)
+}
+
+destLangs.forEach(async (destLang) => {
+	const destFile = path.join(
+		localizedRegionModelsDir,
+		`${model}-${destLang}.yaml`
+	)
+	console.log(
+		'Translating',
+		path.basename(srcFile),
+		'to',
+		path.basename(destFile)
+	)
+	if (existsSync(destFile)) {
+		cli.printWarn(`File ${destFile} already exists.`)
+		const overwrite = prompt('Overwrite? [y/N] ')
+		if (overwrite !== 'y') {
+			cli.printWarn('Skipping...')
+			return
+		}
+	}
+	const translatedModel = await translateModel(srcModel, destLang)
+	utils.writeYAML(destFile, translatedModel)
+})

--- a/scripts/i18n/translateRegionModel.js
+++ b/scripts/i18n/translateRegionModel.js
@@ -23,17 +23,16 @@ const model = destRegions[0]
 const srcFile = path.join(localizedRegionModelsDir, `${model}-${srcLang}.yaml`)
 const srcModel = utils.readYAML(srcFile)
 
-// TODO: there is something to do with async/await here
 const translateRule = async ([ruleName, ruleVal], destLang) => {
-	const translate = async (str) => {
-		return await deepl.fetchTranslation(
+	const translate = (str) => {
+		return deepl.fetchTranslation(
 			str,
 			srcLang.toUpperCase(),
 			destLang.toUpperCase()
 		)
 	}
-	const translateMd = async (str) => {
-		return await deepl.fetchTranslationMarkdown(
+	const translateMd = (str) => {
+		return deepl.fetchTranslationMarkdown(
 			str,
 			srcLang.toUpperCase(),
 			destLang.toUpperCase()
@@ -70,9 +69,8 @@ const translateRule = async ([ruleName, ruleVal], destLang) => {
 								val = translate(val)
 							}
 						}
-						val = await val
 					}
-					return [attr, val]
+					return [attr, await val]
 				})
 			)
 		),

--- a/scripts/i18n/utils.js
+++ b/scripts/i18n/utils.js
@@ -301,4 +301,5 @@ module.exports = {
 	assoc,
 	customAssocPath,
 	publicDir,
+	t9nDir,
 }

--- a/scripts/i18n/utils.js
+++ b/scripts/i18n/utils.js
@@ -9,6 +9,10 @@ const LOCK_KEY_EXT = '.lock'
 const AUTO_KEY_EXT = '.auto'
 const PREVIOUS_REVIEW_KEY_EXT = '.previous_review'
 
+const publicDir = path.resolve('public')
+
+const t9nDir = path.resolve('data/i18n/t9n')
+
 const availableLanguages = ['fr', 'en-us'] //, 'es', 'it'] For now, we don't want es and it to be compile (it could create compilation errors).
 const defaultLang = availableLanguages[0]
 
@@ -296,4 +300,5 @@ module.exports = {
 	objPath,
 	assoc,
 	customAssocPath,
+	publicDir,
 }

--- a/scripts/i18n/utils.js
+++ b/scripts/i18n/utils.js
@@ -149,18 +149,18 @@ const getMissingPersonas = (refPersonas, destPersonas, force = false) => {
 	return missingTranslations
 }
 
-const getMissingRules = (srcRules, targetRules) => {
-	const keysToTranslate = [
-		'titre',
-		'description',
-		'question',
-		'résumé',
-		'note',
-		'suggestions',
-		'mosaique',
-		'abréviation',
-	]
+const mechanismsToTranslate = [
+	'titre',
+	'description',
+	'question',
+	'résumé',
+	'note',
+	'suggestions',
+	'mosaique',
+	'abréviation',
+]
 
+const getMissingRules = (srcRules, targetRules) => {
 	const areEqual = (s1, s2) => {
 		return (
 			JSON.stringify(s1, { sortMapEntries: true }) ===
@@ -185,7 +185,7 @@ const getMissingRules = (srcRules, targetRules) => {
 					// φ => ψ === ¬φ ∨ ψ
 					'mosaique' !== attr || val.suggestions
 				return (
-					keysToTranslate.includes(attr) &&
+					mechanismsToTranslate.includes(attr) &&
 					val !== '' &&
 					mosaiqueIncludeSuggestions
 				)
@@ -194,7 +194,7 @@ const getMissingRules = (srcRules, targetRules) => {
 			if (targetRule) {
 				acc.push(
 					filteredValEntries.reduce((acc, [attr, refVal]) => {
-						if (keysToTranslate.includes(attr)) {
+						if (mechanismsToTranslate.includes(attr)) {
 							let targetRef = targetRule[attr + LOCK_KEY_EXT]
 							let hasTheSameRefValue
 
@@ -302,4 +302,5 @@ module.exports = {
 	customAssocPath,
 	publicDir,
 	t9nDir,
+	mechanismsToTranslate,
 }

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -11,7 +11,7 @@ import { exit } from 'process'
 import Engine from 'publicodes'
 
 import cli from './i18n/cli.js'
-import utils, { publicDir } from './i18n/utils.js'
+import utils, { publicDir, t9nDir } from './i18n/utils.js'
 
 import { addRegionToBaseRules } from './i18n/addRegionToBaseRules.js'
 import { addTranslationToBaseRules } from './i18n/addTranslationToBaseRules.js'

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -11,16 +11,18 @@ import { exit } from 'process'
 import Engine from 'publicodes'
 
 import cli from './i18n/cli.js'
-import utils from './i18n/utils.js'
+import utils, { publicDir } from './i18n/utils.js'
 
 import { addRegionToBaseRules } from './i18n/addRegionToBaseRules.js'
 import { addTranslationToBaseRules } from './i18n/addTranslationToBaseRules.js'
 
 import { compressRules } from './modelOptim.mjs'
-
-const outputJSONPath = './public'
-
-const t9nDir = path.resolve('data/i18n/t9n')
+import {
+	supportedRegionPath,
+	supportedRegions,
+	defaultModelCode,
+	regionsModelsPath,
+} from './i18n/regionCommons.js'
 
 const { srcLang, srcFile, destLangs, destRegions, markdown } = cli.getArgs(
 	`Aggregates the model to an unique JSON file.`,
@@ -34,64 +36,6 @@ const { srcLang, srcFile, destLangs, destRegions, markdown } = cli.getArgs(
 		markdown: true,
 	}
 )
-
-/// ---------------------- Retrieving the regions models ----------------------
-
-const regionsModelsPath = path.resolve('data/i18n/models')
-const defaultModelCode = 'FR'
-const defaultRegionModelParam = {
-	[defaultModelCode]: {
-		nom: 'France métropolitaine',
-		gentilé: 'française',
-		code: defaultModelCode,
-	},
-}
-const supportedRegionPath = path.join(outputJSONPath, `supportedRegions.json`)
-
-//
-// Reads all regions models and create a json file containing params of each region.
-//
-// Only XX.yaml files are read in 'data/i18n/models' directory, their are the base models.
-// (XX-YY.yaml files are not read, they are the translation of the base models.)
-//
-// The default region and hardcoded one is FR.
-//
-const supportedRegions = fs
-	.readdirSync(regionsModelsPath)
-	.reduce((acc, filename) => {
-		if (!filename.match(/([A-Z]{2})-fr.yaml/)) return acc
-		try {
-			const regionPath = path.join(regionsModelsPath, filename)
-			const rules = utils.readYAML(regionPath)
-			const params = rules['params']
-			if (params === undefined) {
-				console.log(
-					` ❌ The file ${filename} doesn't contain a 'params' key, aborting...`
-				)
-				exit(-1)
-			}
-			return { ...acc, [rules.params.code]: params }
-		} catch (err) {
-			console.log(
-				' ❌ An error occured while reading the file:',
-				filename,
-				':\n\n',
-				err.message
-			)
-			exit(-1)
-		}
-	}, defaultRegionModelParam)
-
-const supportedRegionCodes = Object.keys(supportedRegions)
-
-const regions =
-	destRegions?.filter((r) => {
-		if (!supportedRegionCodes.includes(r)) {
-			cli.printWarn(`[WARN] - the region '${r}' is not supported, skipping it.`)
-			return false
-		}
-		return true
-	}) ?? supportedRegionCodes
 
 /// ---------------------- Helper functions ----------------------
 
@@ -186,7 +130,11 @@ glob(srcFile, { ignore: ['data/i18n/**'] }, (_, files) => {
 	}, {})
 
 	try {
-		new Engine(baseRules).evaluate('bilan')
+		new Engine(baseRules, {
+			// NOTE(@EmileRolley): warnings are ignored for now but should be examined in
+			//    https://github.com/datagir/nosgestesclimat/issues/1722
+			logger: { log: (_) => {}, warn: (_) => {}, err: (s) => console.error(s) },
+		}).evaluate('bilan')
 		console.log(
 			markdown
 				? `| Rules evaluation | :heavy_check_mark: | Ø |`
@@ -196,14 +144,14 @@ glob(srcFile, { ignore: ['data/i18n/**'] }, (_, files) => {
 		destLangs.push(srcLang)
 		destLangs.forEach((destLang) => {
 			const translatedBaseRules = getTranslatedRules(baseRules, destLang)
-			regions.forEach((regionCode) => {
+			destRegions.forEach((regionCode) => {
 				const localizedTranslatedBaseRules = getLocalizedRules(
 					translatedBaseRules,
 					regionCode,
 					destLang
 				)
 				const destPathWithoutExtension = path.join(
-					outputJSONPath,
+					publicDir,
 					`co2-model.${regionCode}-lang.${destLang}`
 				)
 				writeRules(

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -588,6 +593,13 @@ prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+prompt-sync@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/prompt-sync/-/prompt-sync-4.2.0.tgz#0198f73c5b70e3b03e4b9033a50540a7c9a1d7f4"
+  integrity sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==
+  dependencies:
+    strip-ansi "^5.0.0"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -703,6 +715,13 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+strip-ansi@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Implement the v0 of #1710.

## Changelog

* New `translateRegionModel.js` script.
* Move code related to region models into a separate file.
* Use a custom logger to avoid polluting the rulesToJSON's output.