### PR TITLE
Feat(scripts/t9n): improvement on the rule translation workflow

### DIFF
--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -17400,6 +17400,22 @@ transport . boulot . commun . type:
   titre: type
   titre.auto: type
   titre.lock: type
+transport . boulot . commun . type . TER:
+  titre: TER
+  titre.auto: TER
+  titre.lock: TER
+transport . boulot . commun . type . bus:
+  titre: Bus
+  titre.auto: Bus
+  titre.lock: Bus
+transport . boulot . commun . type . métro ou tramway:
+  titre: Subway or tramway
+  titre.auto: Subway or tramway
+  titre.lock: Métro ou tramway
+transport . boulot . commun . type . vélo:
+  titre: Bike
+  titre.auto: Bike
+  titre.lock: Vélo
 transport . boulot . covoiturage:
   description: |
     While long-distance carpooling is well known in France, short-distance

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -14277,6 +14277,10 @@ intensité électricité:
   titre: Climate intensity of the French electricity mix
   titre.auto: Climate intensity of the French electricity mix
   titre.lock: Intensité climat du mix électrique français
+jours par an:
+  titre: Number of days per year
+  titre.auto: Number of days per year
+  titre.lock: Nombre de jours par an
 logement:
   abréviation: hous.
   abréviation.auto: logmt.
@@ -15982,14 +15986,6 @@ logement . éteindre appareils . empreinte du foyer:
   titre: footprint of the home
   titre.auto: footprint of the home
   titre.lock: empreinte du foyer
-jours par an:
-  titre: Number of days per year
-  titre.auto: Number of days per year
-  titre.lock: Nombre de jours par an
-semaines par an:
-  titre: Number of weeks per year
-  titre.auto: Number of weeks per year
-  titre.lock: Nombre de semaines par an
 parc français:
   description: |
     The objective of this small model is to estimate the average values associated with the dwelling (surface, surface heated with gas, consumption by heating...) to obtain a total average footprint of the dwelling which is representative of the average French person
@@ -16327,16 +16323,19 @@ parc français . surface totale maisons:
   titre.lock: surface totale maisons
 population:
   note: |
+    French population in 2017 (to remain consistent with the figures of the national footprint estimate)
     A question arises as to whether or not to include the DOM/TOM. We propose to include them.
-    Source SDES for this question: "Kyoto" perimeter, i.e. metropolitan France and overseas territories belonging to the EU"
+    Source SDES for this question: "Kyoto perimeter", i.e. metropolitan France and overseas territories belonging to the EU".
     The source is therefore: https://www.insee.fr/en/statistiques/serie/001760077.
   note.auto: |
+    French population in 2017 (to remain consistent with the figures of the national footprint estimate)
     A question arises as to whether or not to include the DOM/TOM. We propose to include them.
-    Source SDES for this question: "Kyoto" perimeter, i.e. metropolitan France and overseas territories belonging to the EU"
+    Source SDES for this question: "Kyoto perimeter", i.e. metropolitan France and overseas territories belonging to the EU".
     The source is therefore: https://www.insee.fr/en/statistiques/serie/001760077.
   note.lock: |
+    Population française en 2017 (pour rester cohérent avec les chiffres de l'estimation de l'empreinte nationale)
     Une question se pose sur l'inclusion ou non des DOM/TOM. Nous proposons de les inclure.
-    Source SDES pour cette question : "périmètre « Kyoto », soit la France métropolitaine et les outre-mer appartenant à l’UE"
+    Source SDES pour cette question : "périmètre « Kyoto », soit la France métropolitaine et les outre-mer appartenant à l’UE".
     La source est donc bien celle-ci : https://www.insee.fr/en/statistiques/serie/001760077.
   titre: population
   titre.auto: population
@@ -16580,6 +16579,10 @@ pétrole . volume plein:
   titre: full volume
   titre.auto: full volume
   titre.lock: volume plein
+semaines par an:
+  titre: Number of weeks per year
+  titre.auto: Number of weeks per year
+  titre.lock: Nombre de semaines par an
 services marchands:
   abréviation: Merchants
   abréviation.auto: Merchants

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -223,9 +223,16 @@ transport . boulot . commun . type:
         - vélo
 
 transport . boulot . commun . type . bus:
+  titre: Bus
+
 transport . boulot . commun . type . métro ou tramway:
+  titre: Métro ou tramway
+
 transport . boulot . commun . type . TER:
+  titre: TER
+
 transport . boulot . commun . type . vélo:
+  titre: Vélo
 
 transport . bus . empreinte:
   formule: transport . bus . impact par km

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	"dependencies": {
 		"csv-parser": "^3.0.0",
 		"glob": "^8.0.3",
-		"inquirer": "^8.2.5",
 		"nodemon": "^2.0.20",
 		"prettier": "^2.7.1",
 		"publicodes": "^1.0.0-beta.66",

--- a/scripts/i18n/check-translation.js
+++ b/scripts/i18n/check-translation.js
@@ -8,7 +8,7 @@ const path = require('path')
 const glob = require('glob')
 const R = require('ramda')
 const { exit } = require('process')
-const inquirer = require('inquirer')
+const prompt = require('prompt-sync')()
 
 const cli = require('./cli')
 const utils = require('./utils')
@@ -24,14 +24,9 @@ const { destLangs, srcFile, markdown } = cli.getArgs(
 	}
 )
 
-const questions = [
-	{
-		type: 'confirm',
-		name: 'expandMissingRules',
-		message: 'Do you want to log missing rules ?',
-		default: false,
-	},
-]
+const expandMissingRuleQuestion = `Do you want to log missing rules ? ${cli.styledPromptActions(
+	['yes', 'no']
+)}: `
 
 glob(`${srcFile}`, { ignore: ['data/i18n/**'] }, (_, files) => {
 	const rules = R.mergeAll(
@@ -63,11 +58,10 @@ glob(`${srcFile}`, { ignore: ['data/i18n/**'] }, (_, files) => {
 			destLang,
 			markdown
 		)
-		if (nbMissing > 0) {
-			inquirer.prompt(questions).then((answers) => {
-				answers.expandMissingRules &&
-					missingRuleNames.map((rule) => cli.printWarn(rule))
-			})
+		if (nbMissing > 0 && 'y' === prompt(expandMissingRuleQuestion)) {
+			missingRules.map(({ rule: ruleName, attr }) =>
+				console.log(cli.styledRuleNameWithOptionalAttr(ruleName, attr))
+			)
 		}
 	})
 })

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -36,6 +36,7 @@ const colors = {
 const withStyle = (color, text) => `${color}${text}${colors.reset}`
 const printErr = (message) => console.error(withStyle(colors.fgRed, message))
 const printWarn = (message) => console.warn(withStyle(colors.fgYellow, message))
+const printInfo = (message) => console.log(withStyle(colors.fgCyan, message))
 
 const yellow = (str) => withStyle(colors.fgYellow, str)
 const red = (str) => withStyle(colors.fgRed, str)
@@ -72,6 +73,8 @@ const printChecksResult = (
 	}
 }
 
+// TODO:
+// - switch to typescript in order to specify the type of opts
 const getArgs = (description, opts) => {
 	let args = yargs.usage(`${description}\n\nUsage: node $0 [options]`)
 
@@ -133,6 +136,13 @@ const getArgs = (description, opts) => {
 			description: 'Prints the result in a Markdown table format.',
 		})
 	}
+	if (opts.onlyUpdateLocks) {
+		args = args.option('only-update-locks', {
+			alias: 'u',
+			type: 'boolean',
+			description: 'Only update the lock attributes, do not translate.',
+		})
+	}
 
 	const argv = args.help().alias('help', 'h').argv
 
@@ -162,6 +172,7 @@ const getArgs = (description, opts) => {
 		remove: argv.remove,
 		srcFile,
 		markdown: argv.markdown,
+		onlyUpdateLocks: argv.onlyUpdateLocks,
 	}
 }
 
@@ -185,6 +196,7 @@ module.exports = {
 	green,
 	printErr,
 	printWarn,
+	printInfo,
 	red,
 	withStyle,
 	yellow,

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -5,7 +5,6 @@
 const yargs = require('yargs')
 
 const utils = require('./utils')
-const regions = require('./regionCommons')
 
 const colors = {
 	reset: '\x1b[0m',
@@ -75,6 +74,7 @@ const printChecksResult = (
 
 // TODO:
 // - switch to typescript in order to specify the type of opts
+// - could be cleaner
 const getArgs = (description, opts) => {
 	let args = yargs.usage(`${description}\n\nUsage: node $0 [options]`)
 
@@ -125,7 +125,7 @@ const getArgs = (description, opts) => {
 			alias: 'o',
 			type: 'string',
 			array: true,
-			choices: regions.supportedRegionCodes,
+			choices: opts.model.supportedRegionCodes,
 			description: 'The region code model.',
 		})
 	}
@@ -157,7 +157,7 @@ const getArgs = (description, opts) => {
 		return l !== srcLang
 	})
 
-	const destRegions = argv.model ?? regions.supportedRegionCodes
+	const destRegions = argv.model ?? opts?.model?.supportedRegionCodes
 
 	const srcFile = argv.file ?? opts.defaultSrcFile
 

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -200,6 +200,17 @@ const exitIfError = (error, msg = undefined, progressBar = undefined) => {
 	}
 }
 
+const styledRuleNameWithOptionalAttr = (ruleName, attr) =>
+	`${magenta(ruleName)}${
+		attr !== undefined ? ` ${dim('>')} ${yellow(attr)}` : ''
+	}`
+
+const styledPromptAction = (action) =>
+	`[${action[0]}]${dim(action.substring(1))}`
+
+const styledPromptActions = (actions) =>
+	actions.map((action) => styledPromptAction(action)).join(' ')
+
 module.exports = {
 	colors,
 	dim,
@@ -215,4 +226,7 @@ module.exports = {
 	yellow,
 	printChecksResult,
 	printChecksResultTableHeader,
+	styledRuleNameWithOptionalAttr,
+	styledPromptAction,
+	styledPromptActions,
 }

--- a/scripts/i18n/cli.js
+++ b/scripts/i18n/cli.js
@@ -40,6 +40,8 @@ const printInfo = (message) => console.log(withStyle(colors.fgCyan, message))
 const yellow = (str) => withStyle(colors.fgYellow, str)
 const red = (str) => withStyle(colors.fgRed, str)
 const green = (str) => withStyle(colors.fgGreen, str)
+const magenta = (str) => withStyle(colors.fgMagenta, str)
+const dim = (str) => withStyle(colors.dim, str)
 
 const printChecksResultTableHeader = (markdown) => {
 	if (markdown) {
@@ -143,6 +145,14 @@ const getArgs = (description, opts) => {
 			description: 'Only update the lock attributes, do not translate.',
 		})
 	}
+	if (opts.interactiveMode) {
+		args = args.option('interactive-mode', {
+			alias: 'i',
+			type: 'boolean',
+			description:
+				'Launch the interactive mode, to translate one rule at a time with the possibility to only update the lock attributes.',
+		})
+	}
 
 	const argv = args.help().alias('help', 'h').argv
 
@@ -173,6 +183,7 @@ const getArgs = (description, opts) => {
 		srcFile,
 		markdown: argv.markdown,
 		onlyUpdateLocks: argv.onlyUpdateLocks,
+		interactiveMode: argv.interactiveMode,
 	}
 }
 
@@ -191,9 +202,11 @@ const exitIfError = (error, msg = undefined, progressBar = undefined) => {
 
 module.exports = {
 	colors,
+	dim,
 	exitIfError,
 	getArgs,
 	green,
+	magenta,
 	printErr,
 	printWarn,
 	printInfo,

--- a/scripts/i18n/regionCommons.js
+++ b/scripts/i18n/regionCommons.js
@@ -5,8 +5,8 @@ const fs = require('fs')
 const { exit } = require('process')
 
 const { publicDir, readYAML } = require('./utils')
+const regionModelsPath = path.resolve('data/i18n/models')
 
-const regionsModelsPath = path.resolve('data/i18n/models')
 const defaultModelCode = 'FR'
 const defaultRegionModelParam = {
 	[defaultModelCode]: {
@@ -26,11 +26,11 @@ const supportedRegionPath = path.join(publicDir, `supportedRegions.json`)
 // The default region and hardcoded one is FR.
 //
 const supportedRegions = fs
-	.readdirSync(regionsModelsPath)
+	.readdirSync(regionModelsPath)
 	.reduce((acc, filename) => {
 		if (!filename.match(/([A-Z]{2})-fr.yaml/)) return acc
 		try {
-			const regionPath = path.join(regionsModelsPath, filename)
+			const regionPath = path.join(regionModelsPath, filename)
 			const rules = readYAML(regionPath)
 			const params = rules['params']
 			if (params === undefined) {
@@ -58,5 +58,5 @@ module.exports = {
 	supportedRegionCodes,
 	supportedRegions,
 	defaultModelCode,
-	regionsModelsPath,
+	regionModelsPath,
 }

--- a/scripts/i18n/translate-rules.js
+++ b/scripts/i18n/translate-rules.js
@@ -100,9 +100,14 @@ const translateTo = async (
 			if (interactiveMode) {
 				do {
 					answer = prompt(
-						`Action for rule ${cli.magenta(rule)}: [t]${cli.dim(
-							'ranslate'
-						)}, [u]${cli.dim('pdate .lock attribute')} , [s]${cli.dim('kip')}: `
+						`${cli.styledRuleNameWithOptionalAttr(
+							rule,
+							attr
+						)}}:\n${cli.styledPromptActions([
+							'translate',
+							'update .lock attribute',
+							'skip',
+						])}: `
 					)
 				} while (!['u', 's', 't'].includes(answer))
 			}

--- a/scripts/i18n/translate-rules.js
+++ b/scripts/i18n/translate-rules.js
@@ -99,19 +99,13 @@ const translateTo = async (
 			let answer
 			if (interactiveMode) {
 				do {
-					answer = prompt(
-						`${cli.styledRuleNameWithOptionalAttr(
-							rule,
-							attr
-						)}}:\n${cli.styledPromptActions([
-							'translate',
-							'update .lock attribute',
-							'skip',
-						])}: `
-					)
-				} while (!['u', 's', 't'].includes(answer))
+					answer = prompt(`${cli.styledRuleNameWithOptionalAttr(rule, attr)}: `)
+				} while (!['u', 's', 't', 'a'].includes(answer))
 			}
-			if (answer === 's') {
+			if (answer === 'a') {
+				console.log('Exiting...')
+				exit(0)
+			} else if (answer === 's') {
 				return skippedValues.push({ rule, msg: 'skipped' })
 			}
 
@@ -192,6 +186,16 @@ glob(`${srcFile}`, { ignore: ['data/i18n/**'] }, (_, files) => {
 					missingRules.length
 				)} new entries to ${cli.yellow(destLang)}...`
 			)
+			if (interactiveMode) {
+				console.log(
+					`For each rule, you can choose to:\n\n\t${cli.styledPromptActions([
+						'translate',
+						'update .lock attribute',
+						'skip',
+						'abort',
+					])}\n`
+				)
+			}
 
 			translateTo(srcLang, destLang, destPath, missingRules, destRules)
 		} else {

--- a/scripts/i18n/translateRegionModel.js
+++ b/scripts/i18n/translateRegionModel.js
@@ -6,21 +6,23 @@ const cli = require('./cli')
 const deepl = require('./deepl')
 const utils = require('./utils')
 
-const localizedRegionModelsDir = path.resolve('./data/i18n/models/')
+const { regionModelsPath, supportedRegionCodes } = require('./regionCommons')
 
 const { srcLang, destLangs, destRegions } = cli.getArgs(
-	`Translates localized region models stored in ${localizedRegionModelsDir}.`,
+	`Translates localized region models stored in ${regionModelsPath}.`,
 	{
 		source: true,
 		target: true,
-		model: true,
+		model: { supportedRegionCodes },
 	}
 )
 
 // TODO: support multiple models
 const model = destRegions[0]
 
-const srcFile = path.join(localizedRegionModelsDir, `${model}-${srcLang}.yaml`)
+console.log('regionModelsPath', regionModelsPath)
+
+const srcFile = path.join(regionModelsPath, `${model}-${srcLang}.yaml`)
 const srcModel = utils.readYAML(srcFile)
 
 const translateRule = async ([ruleName, ruleVal], destLang) => {
@@ -99,10 +101,7 @@ const translateModel = async (srcRules, destLang) => {
 }
 
 destLangs.forEach(async (destLang) => {
-	const destFile = path.join(
-		localizedRegionModelsDir,
-		`${model}-${destLang}.yaml`
-	)
+	const destFile = path.join(regionModelsPath, `${model}-${destLang}.yaml`)
 	console.log(
 		'Translating',
 		path.basename(srcFile),

--- a/scripts/i18n/translateRegionModel.js
+++ b/scripts/i18n/translateRegionModel.js
@@ -20,8 +20,6 @@ const { srcLang, destLangs, destRegions } = cli.getArgs(
 // TODO: support multiple models
 const model = destRegions[0]
 
-console.log('regionModelsPath', regionModelsPath)
-
 const srcFile = path.join(regionModelsPath, `${model}-${srcLang}.yaml`)
 const srcModel = utils.readYAML(srcFile)
 

--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -21,7 +21,8 @@ import {
 	supportedRegionPath,
 	supportedRegions,
 	defaultModelCode,
-	regionsModelsPath,
+	regionModelsPath,
+	supportedRegionCodes,
 } from './i18n/regionCommons.js'
 
 const { srcLang, srcFile, destLangs, destRegions, markdown } = cli.getArgs(
@@ -30,7 +31,7 @@ const { srcLang, srcFile, destLangs, destRegions, markdown } = cli.getArgs(
 	{
 		source: true,
 		target: true,
-		model: true,
+		model: { supportedRegionCodes },
 		file: true,
 		defaultSrcFile: 'data/**/*.yaml',
 		markdown: true,
@@ -99,7 +100,7 @@ function getLocalizedRules(translatedBaseRules, regionCode, destLang) {
 		return translatedBaseRules
 	}
 	const localizedAttrs = utils.readYAML(
-		path.join(regionsModelsPath, `${regionCode}-${destLang}.yaml`) ?? {}
+		path.join(regionModelsPath, `${regionCode}-${destLang}.yaml`) ?? {}
 	)
 	return addRegionToBaseRules(translatedBaseRules, localizedAttrs)
 }
@@ -179,7 +180,7 @@ glob(srcFile, { ignore: ['data/i18n/**'] }, (_, files) => {
 					console.log('  ', lines[i])
 				}
 			}
-			console.log()
+			console.log(err)
 		}
 	}
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,13 +17,6 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-ansi-escapes@^4.2.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
-  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
-  dependencies:
-    type-fest "^0.21.3"
-
 ansi-regex@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
@@ -34,7 +27,7 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -68,24 +61,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-bl@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
-  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -109,27 +88,6 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-buffer@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
-
-chalk@^4.1.0, chalk@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
 chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -145,29 +103,12 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
-  dependencies:
-    restore-cursor "^3.1.0"
-
 cli-progress@^3.11.2:
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.11.2.tgz#f8c89bd157e74f3f2c43bcfb3505670b4d48fc77"
   integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
   dependencies:
     string-width "^4.2.3"
-
-cli-spinners@^2.5.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
-  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
-
-cli-width@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
-  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -177,11 +118,6 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
-
-clone@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
-  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -231,13 +167,6 @@ deepl-node@^1.7.0:
     form-data "^3.0.0"
     loglevel ">=1.6.2"
 
-defaults@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
-  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
-  dependencies:
-    clone "^1.0.2"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -257,27 +186,6 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
-
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
-external-editor@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
-
-figures@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -347,23 +255,6 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-iconv-lite@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -377,31 +268,10 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-inquirer@^8.2.5:
-  version "8.2.5"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
-  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.1"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.21"
-    mute-stream "0.0.8"
-    ora "^5.4.1"
-    run-async "^2.4.0"
-    rxjs "^7.5.5"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-    wrap-ansi "^7.0.0"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -427,20 +297,10 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-interactive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
-  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
-
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-is-unicode-supported@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
-  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 isomorphic-fetch@^3.0.0:
   version "3.0.0"
@@ -449,19 +309,6 @@ isomorphic-fetch@^3.0.0:
   dependencies:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
-
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-log-symbols@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
-  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
-  dependencies:
-    chalk "^4.1.0"
-    is-unicode-supported "^0.1.0"
 
 loglevel@>=1.6.2:
   version "1.8.0"
@@ -479,11 +326,6 @@ mime-types@^2.1.12:
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
-
-mimic-fn@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.1.2:
   version "3.1.2"
@@ -508,11 +350,6 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-mute-stream@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 node-fetch@^2.6.1:
   version "2.6.7"
@@ -555,33 +392,6 @@ once@^1.3.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-onetime@^5.1.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
-  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  dependencies:
-    mimic-fn "^2.1.0"
-
-ora@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
-  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
-  dependencies:
-    bl "^4.1.0"
-    chalk "^4.1.0"
-    cli-cursor "^3.1.0"
-    cli-spinners "^2.5.0"
-    is-interactive "^1.0.0"
-    is-unicode-supported "^0.1.0"
-    log-symbols "^4.1.0"
-    strip-ansi "^6.0.0"
-    wcwidth "^1.0.1"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
@@ -627,15 +437,6 @@ ramda@^0.28.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
   integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
 
-readable-stream@^3.4.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -648,36 +449,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
-run-async@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
-  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
-rxjs@^7.5.5:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
-  dependencies:
-    tslib "^2.1.0"
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-"safer-buffer@>= 2.1.2 < 3":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
 semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -687,11 +458,6 @@ semver@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
-
-signal-exit@^3.0.2:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
-  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 simple-update-notifier@^1.0.7:
   version "1.1.0"
@@ -708,13 +474,6 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 strip-ansi@^5.0.0:
   version "5.2.0"
@@ -737,25 +496,6 @@ supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-through@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -775,32 +515,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tslib@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
 undefsafe@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-wcwidth@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
-  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
-  dependencies:
-    defaults "^1.0.3"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Start to implement some of the tasks listed in the meta issue https://github.com/datagir/nosgestesclimat-site/issues/782.

## Demo

### Interactive mode

https://user-images.githubusercontent.com/44124798/223399694-5ba0e4cd-b4f8-407d-a067-783c14297044.mp4

## Changelog

- New `--only-update-locks` flag for rules translation -- closing https://github.com/datagir/nosgestesclimat-site/issues/871.
- New `--interactive-mode` flag for rules translation.
- Remove the `regionCommons.js` dependency from `cli.js` -- which are used by the scripts in the website repository.
- Add missing translation -- fixing #1765 
- Remove the progress bar for the rule translation.
- Replace the `inquirer` dependency by the simpler one `prompt-sync` for user interaction in the CLI.