### PR TITLE
TVA ratio monétaire

### DIFF
--- a/data/divers/divers.yaml
+++ b/data/divers/divers.yaml
@@ -58,7 +58,7 @@ divers . autres produits . amortissement:
   unité: an
 
 divers . autres produits . ratio monétaire:
-  titre: Ratio monétaire produits manufacturés HT
+  titre: Ratio monétaire produits manufacturés TTC
   formule: ratio monétaire HT * 0.8
   note: On considère une TVA de 20% (taux majoritairement appliqué aux dépenses de cette question).
 

--- a/data/divers/divers.yaml
+++ b/data/divers/divers.yaml
@@ -58,7 +58,12 @@ divers . autres produits . amortissement:
   unité: an
 
 divers . autres produits . ratio monétaire:
-  titre: Ratio monétaire produits manufacturés
+  titre: Ratio monétaire produits manufacturés HT
+  formule: ratio monétaire HT * 0.8
+  note: On considère une TVA de 20% (taux majoritairement appliqué aux dépenses de cette question).
+
+divers . autres produits . ratio monétaire HT:
+  titre: Ratio monétaire produits manufacturés HT
   formule: (plastiques et caoutchouc + papier et carton + bois et articles en bois + produits métalliques + édition) / 5
   unité: kgCO2e/€
   description: |

--- a/data/divers/divers.yaml
+++ b/data/divers/divers.yaml
@@ -70,31 +70,31 @@ divers . autres produits . ratio monétaire HT:
     Dans une première approche, ce ratio est basé sur une moyenne de facteurs d'émission monétaires issus de la base carbone. 
     Voir [documentation de la base carbone](https://bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Ratio-monetaires).
 
-divers . autres produits . ratio monétaire . plastiques et caoutchouc:
+divers . autres produits . ratio monétaire HT . plastiques et caoutchouc:
   titre: Ratio monétaire plastiques et caoutchouc
   formule: 0.800
   unité: kgCO2e/€
   note: Base Carbone - Service - Plastiques et caoutchouc
 
-divers . autres produits . ratio monétaire . papier et carton:
+divers . autres produits . ratio monétaire HT . papier et carton:
   titre: Ratio monétaire papier et carton
   formule: 0.900
   unité: kgCO2e/€
   note: Base Carbone - Service - Papier et carton (/€ HT)
 
-divers . autres produits . ratio monétaire . bois et articles en bois:
+divers . autres produits . ratio monétaire HT . bois et articles en bois:
   titre: Ratio monétaire bois
   formule: 0.500
   unité: kgCO2e/€
   note: Base Carbone - Service - Bois et article en bois (/€ HT)
 
-divers . autres produits . ratio monétaire . produits métalliques:
+divers . autres produits . ratio monétaire HT . produits métalliques:
   titre: Ratio monétaire produits métalliques
   formule: 0.600
   unité: kgCO2e/€
   note: Base Carbone - Service - Produits métalliques, sauf machines et équipements (/€ HT)
 
-divers . autres produits . ratio monétaire . édition:
+divers . autres produits . ratio monétaire HT . édition:
   titre: Ratio monétaire édition
   formule: 0.280
   unité: kgCO2e/€

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -5097,9 +5097,9 @@ divers . autres produits . ratio monétaire:
   note: We consider a VAT rate of 20% (the rate mostly applied to the expenses of this question).
   note.auto: We consider a VAT rate of 20% (the rate mostly applied to the expenses of this question).
   note.lock: On considère une TVA de 20% (taux majoritairement appliqué aux dépenses de cette question).
-  titre: Monetary ratio of manufactured products excluding VAT
-  titre.auto: Monetary ratio of manufactured products excluding VAT
-  titre.lock: Ratio monétaire produits manufacturés HT
+  titre: Monetary ratio of manufactured products including VAT
+  titre.auto: Monetary ratio of manufactured products including VAT
+  titre.lock: Ratio monétaire produits manufacturés TTC
 divers . autres produits . ratio monétaire HT:
   description: |
     In a first approach, this ratio is based on an average of monetary emission factors from the carbon base. 

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -5094,6 +5094,13 @@ divers . autres produits . notif ratio monétaire:
   titre.auto: notification monetary ratio
   titre.lock: notif ratio monétaire
 divers . autres produits . ratio monétaire:
+  note: We consider a VAT rate of 20% (the rate mostly applied to the expenses of this question).
+  note.auto: We consider a VAT rate of 20% (the rate mostly applied to the expenses of this question).
+  note.lock: On considère une TVA de 20% (taux majoritairement appliqué aux dépenses de cette question).
+  titre: Monetary ratio of manufactured products excluding VAT
+  titre.auto: Monetary ratio of manufactured products excluding VAT
+  titre.lock: Ratio monétaire produits manufacturés HT
+divers . autres produits . ratio monétaire HT:
   description: |
     In a first approach, this ratio is based on an average of monetary emission factors from the carbon base. 
     See <a href="https://bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Ratio-monetaires">documentation of the carbon base</a>.
@@ -5103,38 +5110,38 @@ divers . autres produits . ratio monétaire:
   description.lock: |
     Dans une première approche, ce ratio est basé sur une moyenne de facteurs d'émission monétaires issus de la base carbone. 
     Voir [documentation de la base carbone](https://bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Ratio-monetaires).
-  titre: Monetary ratio manufactured products
-  titre.auto: Monetary ratio manufactured products
-  titre.lock: Ratio monétaire produits manufacturés
-divers . autres produits . ratio monétaire . bois et articles en bois:
+  titre: Monetary ratio of manufactured products excluding VAT
+  titre.auto: Monetary ratio of manufactured products excluding VAT
+  titre.lock: Ratio monétaire produits manufacturés HT
+divers . autres produits . ratio monétaire HT . bois et articles en bois:
   note: Base Carbone - Service - Wood and wood products (/€ HT)
   note.auto: Base Carbone - Service - Wood and wood products (/€ HT)
   note.lock: Base Carbone - Service - Bois et article en bois (/€ HT)
   titre: Monetary ratio wood
   titre.auto: Monetary ratio wood
   titre.lock: Ratio monétaire bois
-divers . autres produits . ratio monétaire . papier et carton:
+divers . autres produits . ratio monétaire HT . papier et carton:
   note: Carbon Basis - Service - Paper and cardboard (/€ HT)
   note.auto: Carbon Basis - Service - Paper and cardboard (/€ HT)
   note.lock: Base Carbone - Service - Papier et carton (/€ HT)
   titre: Paper and cardboard monetary ratio
   titre.auto: Paper and cardboard monetary ratio
   titre.lock: Ratio monétaire papier et carton
-divers . autres produits . ratio monétaire . plastiques et caoutchouc:
+divers . autres produits . ratio monétaire HT . plastiques et caoutchouc:
   note: Base Carbone - Service - Plastics and rubber
   note.auto: Base Carbone - Service - Plastics and rubber
   note.lock: Base Carbone - Service - Plastiques et caoutchouc
   titre: Monetary ratio plastics and rubber
   titre.auto: Monetary ratio plastics and rubber
   titre.lock: Ratio monétaire plastiques et caoutchouc
-divers . autres produits . ratio monétaire . produits métalliques:
+divers . autres produits . ratio monétaire HT . produits métalliques:
   note: Carbon Footprint - Service - Metal products, except machinery and equipment (/€ HT)
   note.auto: Carbon Footprint - Service - Metal products, except machinery and equipment (/€ HT)
   note.lock: Base Carbone - Service - Produits métalliques, sauf machines et équipements (/€ HT)
   titre: Monetary ratio of metal products
   titre.auto: Monetary ratio of metal products
   titre.lock: Ratio monétaire produits métalliques
-divers . autres produits . ratio monétaire . édition:
+divers . autres produits . ratio monétaire HT . édition:
   note: Carbon Footprint - Service/Publishing (books, newspapers, magazines, etc.) (/€ HT)
   note.auto: Carbon Footprint - Service/Publishing (books, newspapers, magazines, etc.) (/€ HT)
   note.lock: Base Carbone - Service/Édition (livres, journaux, revues, etc.) (/€ HT)
@@ -5168,14 +5175,6 @@ divers . déchets . recyclage:
   titre: Recycle my goods
   titre.auto: Recycle my goods
   titre.lock: Recycler mes biens
-divers . meubles . allongement:
-  titre: Extend the life of my furniture
-  titre.auto: Extend the life of my furniture
-  titre.lock: Allonger la vie de mes meubles
-divers . meubles . seconde main:
-  titre: Buy my furniture second hand
-  titre.auto: Buy my furniture second hand
-  titre.lock: Acheter mes meubles d'occasion
 divers . numérique:
   abréviation: number.
   abréviation.auto: number.
@@ -15644,7 +15643,7 @@ logement . chauffage . bouteille gaz . consommation:
 
     La bouteille la plus répandue est le modèle de 13kg, généralement utilisée pour le gaz de cuisson. On considère donc pour cette question une bouteille de 13kg.
 
-    Etant donné que les bouteilles elles-mêmes sont consignées, on ne prend en compte ici que le gaz seul.
+    Étant donné que les bouteilles elles-mêmes sont consignées, nous prenons en compte uniquement les émissions liées au gaz seul.
   question: What is your annual consumption of gas bottles (13 kg)?
   question.auto: What is your annual consumption of gas bottles (13 kg)?
   question.lock: Quelle est votre consommation annuelle en bouteilles de gaz (13 kg) ?
@@ -15732,9 +15731,42 @@ logement . chauffage . citerne propane . consommation:
   titre.auto: consumption
   titre.lock: consommation
 logement . chauffage . citerne propane . energie par kg:
-  note: Heating value of propane
-  note.auto: Heating value of propane
-  note.lock: Pouvoir calorifique du propane
+  note: |
+    Documentation of the carbon base:
+    Heating value of propane = 46 MJ/kg (ICP)
+    Ratio PCI/PCS = 1.087
+    1 kWh = 3.6 MJ
+
+    We reason in HCV (consumption).
+
+    The calculation gives 13.88 kWh/kg (HCV)
+
+    ![](https://user-images.githubusercontent.com/55186402/224317812-b646f6d9-1b41-43f3-9823-0295a57dd6c1.png)
+    ![](https://user-images.githubusercontent.com/55186402/224318088-78940efa-2201-407f-9905-545b2f3e09d8.png)
+  note.auto: |
+    Documentation of the carbon base:
+    Heating value of propane = 46 MJ/kg (ICP)
+    Ratio PCI/PCS = 1.087
+    1 kWh = 3.6 MJ
+
+    We reason in HCV (consumption).
+
+    The calculation gives 13.88 kWh/kg (HCV)
+
+    ![](https://user-images.githubusercontent.com/55186402/224317812-b646f6d9-1b41-43f3-9823-0295a57dd6c1.png)
+    ![](https://user-images.githubusercontent.com/55186402/224318088-78940efa-2201-407f-9905-545b2f3e09d8.png)
+  note.lock: |
+    Documentation de la base carbone:
+    Pouvoir calorifique du propane = 46 MJ/kg (PCI)
+    Rapport PCI/PCS = 1,087
+    1 kWh = 3,6 MJ
+
+    On raisonne en PCS (consommation).
+
+    Le calcul donne 13.88 kWh/kg (PCS)
+
+    ![](https://user-images.githubusercontent.com/55186402/224317812-b646f6d9-1b41-43f3-9823-0295a57dd6c1.png)
+    ![](https://user-images.githubusercontent.com/55186402/224318088-78940efa-2201-407f-9905-545b2f3e09d8.png)
   titre: energy per kg
   titre.auto: energy per kg
   titre.lock: energie par kg


### PR DESCRIPTION
Le FE de la base carbone est en kgC02e/€HT. L'input de la question dépenses est en €TTC. Il est nécessaire d'avoir un FE en  kgC02e/€HT 

Je merge directement, c'est une grosse erreur de ma part @lbranaa @Benjamin-Boisserie-ABC @laem 