### PR TITLE
Questions "essentielles" dans le test

### DIFF
--- a/data/logement/logement.yaml
+++ b/data/logement/logement.yaml
@@ -18,8 +18,17 @@ logement . impact:
       - électricité
       - chauffage
       - climatisation
+      - question propriétaire
       - transport . vacances . caravane . empreinte . construction amortie
       - transport . vacances . camping car . empreinte . construction amortie
+
+logement . question propriétaire:
+  titre: Question propriétaire
+  applicable si: propriétaire
+  note: |
+    L'introduction de cette règle permet de poser la question de la propriété directement dans le test 
+    pour que les actions qui dépendent de cette conditions soient d'emblée, adaptées au profil de l'utilisateur.
+  formule: 0
 
 logement . habitants:
   question: Combien de personnes vivent chez vous ?

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -113,6 +113,7 @@ transport . boulot:
 transport . boulot . covoiturage:
   titre: Aller au travail en covoiturage
   effort: modéré
+  non applicable si: télétravail compatible = 'pas de travail'
   applicable si:
     toutes ces conditions:
       - voiture . propriétaire
@@ -199,6 +200,7 @@ transport . boulot . commun:
     >💡 Le saviez-vous ? L'État et beaucoup de régions ou villes subventionnent les vélos mécaniques, électriques, cargo, pliants, etc. [Calculez votre aide 🚲️ en 3 clics](https://mesaidesvelo.fr).
 
   applicable si: voiture . km > seuil d'activation boulot
+  non applicable si: télétravail compatible = 'pas de travail'
   formule: boulot . distance * gain empreinte au km
 
 transport . seuil d'activation boulot:
@@ -282,7 +284,7 @@ transport . boulot . télétravail:
     Dans ce calcul, nous ne prenons en compte que les jours télétravaillés qui évitent un déplacement en voiture individuelle.
   applicable si:
     toutes ces conditions:
-      - compatible
+      - télétravail compatible = 'télétravail possible'
       - voiture . km > seuil d'activation boulot
       - jours travaillés en voiture > 0
   formule: empreinte jour voiture * jours gagnés * transport . boulot . semaines
@@ -307,9 +309,24 @@ transport . boulot . jours télétravaillés:
     5: 5
 # TODO introduire des contrôles (mise à jour de publicodes nécessaire) ici : pas de jours de télétravail supplémentaires à
 
-transport . boulot . télétravail . compatible:
-  question: Votre travail est-il totalement ou en partie compatible avec le télétravail ?
-  par défaut: oui
+transport . boulot . télétravail compatible:
+  question: Si vous êtes en activité professionelle, votre travail est-il totalement ou en partie compatible avec le télétravail ?
+  description: à compléter
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - pas de travail
+        - télétravail possible
+        - télétravail impossible
+  par défaut: "'télétravail possible'"
+
+transport . boulot . télétravail compatible . télétravail impossible:
+  titre: Non
+transport . boulot . télétravail compatible . télétravail possible:
+  titre: Oui
+transport . boulot . télétravail compatible . pas de travail:
+  titre: Je ne suis pas en activité professionelle
 
 transport . voiture 5km:
   titre: Se passer de voiture pour moins de 5 km

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -25,6 +25,15 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - question télétravail
+
+transport . empreinte . question télétravail:
+  titre: Question télétravail
+  applicable si: boulot . télétravail compatible
+  note: |
+    L'introduction de cette règle permet de poser la question du télétravail directement dans le test 
+    pour que les actions qui dépendent de cette conditions soient d'emblée, adaptées au profil de l'utilisateur.
+  formule: 0
 
 transport . vacances:
   mosaique:


### PR DESCRIPTION
Cette PR fait suite à #1784 et une remarque de @laem sur le changement important de l'UX lié à l'introduction de questions sans incidence sur le résultat directement dans le test.
C'est ce qui est proposé ici.

On peut alors se demander: est ce que l'utilisateur va comprendre que cette question a un impact sur son bilan ? alors que ce n'est pas le cas ..

L'idée à la base était :

- D'avoir un top 3 des actions cohérent avec sa situation
- De ne pas afficher les actions liées aux questions de "propriété" et "activit pro" d'emblée ce qui semble gêné (bcp de retours en ce sens)

A noter un bug publicodes: à priori il n'est pas possible de nommer des règles "oui" ou "non":
```yaml
transport . boulot . télétravail . compatible:
  question: Si vous êtes en activité professionelle, votre travail est-il totalement ou en partie compatible avec le télétravail ?
  description: à compléter
  applicable si: voiture . km > seuil d'activation boulot
  formule:
    une possibilité:
      choix obligatoire: oui
      possibilités:
        - non
        - pas de travail
        - oui
  par défaut: oui
transport . boulot . télétravail . compatible . oui:
transport . boulot . télétravail . compatible . non:
transport . boulot . télétravail . compatible . pas de travail:
  titre: Je ne suis pas en activité professionelle

```