### PR TITLE
Fix personas règles appareils numérique

### DIFF
--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -12,7 +12,7 @@ personas . deux tonnes:
     Madame ou monsieur 2 tonnes a déjà atteint l'objectif d'une empreinte climat durable.
   icônes: ✅
   data:
-    alimentation . déchets . niveau d'engagement: "'affirmatif'"
+    alimentation . déchets . quantité jetée: "'zéro déchet'"
     alimentation . gaspillage alimentaire . fréquence: "'jamais'"
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de soja'"
@@ -106,7 +106,10 @@ personas . corentin paris:
     Presque zéro voiture, vit seul dans un studio au gaz, presque végétarien.
   icônes: 🛴🏢
   data:
-    alimentation . déchets . niveau d'engagement: "'affirmatif'"
+    alimentation . déchets . quantité jetée: "'réduction'"
+    alimentation . déchets . gestes . compostage biodéchets . présent: non
+    alimentation . déchets . gestes . gaspillage alimentaire . présent: oui
+    alimentation . déchets . gestes . stop pub . présent: oui
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de soja'"
     alimentation . boisson . sucrées . litres:
@@ -205,7 +208,10 @@ personas . sandy pacé:
     Vit à 11km de Rennes dans une grande maison seule avec ses deux enfants. Chauffage gaz. 20 000km de voiture partagés entre le travail et les activités des enfants.
     Fait attention à ses équipements et a un budget serré.
   data:
-    alimentation . déchets . niveau d'engagement: "'en partie'"
+    alimentation . déchets . quantité jetée: "'réduction'"
+    alimentation . déchets . gestes . compostage biodéchets . présent: non
+    alimentation . déchets . gestes . gaspillage alimentaire . présent: non
+    alimentation . déchets . gestes . stop pub . présent: oui
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de soja'"
     alimentation . boisson . sucrées . litres:
@@ -305,7 +311,7 @@ personas . mehdi agen:
     Adore la viande. Branché tech et jeux vidéos.
   icônes: 🚗🥩
   data:
-    alimentation . déchets . niveau d'engagement: "'pas du tout'"
+    alimentation . déchets . quantité jetée: "'base'"
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de vache'"
     alimentation . boisson . sucrées . litres:
@@ -402,7 +408,10 @@ personas . ximun arcangues:
     Aime les bières locales. Plutôt viande mais est ouvert à toutes les gastronomies. Fait assez attention à ses équipements.
   icônes: 🚌🏚️
   data:
-    alimentation . déchets . niveau d'engagement: "'en partie'"
+    alimentation . déchets . quantité jetée: "'réduction'"
+    alimentation . déchets . gestes . compostage biodéchets . présent: oui
+    alimentation . déchets . gestes . gaspillage alimentaire . présent: oui
+    alimentation . déchets . gestes . stop pub . présent: oui
     alimentation . petit déjeuner . type: "'français'"
     alimentation . boisson . sucrées . litres:
       valeur: 0
@@ -511,7 +520,7 @@ personas . marie laval:
     Grande amatrice de viande et de bière. Boit de l'eau en bouteille et aime la boisson.
   icônes: 🚗🥩
   data:
-    alimentation . déchets . niveau d'engagement: "'pas du tout'"
+    alimentation . déchets . quantité jetée: "'base'"
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de vache'"
     alimentation . boisson . sucrées . litres:
@@ -553,7 +562,10 @@ personas . jessica lyon:
     transport . avion . long courrier . heures de vol:
       valeur: 14
       unité: h / an
-    alimentation . déchets . niveau d'engagement: "'affirmatif'"
+    alimentation . déchets . quantité jetée: "'réduction'"
+    alimentation . déchets . gestes . compostage biodéchets . présent: oui
+    alimentation . déchets . gestes . gaspillage alimentaire . présent: oui
+    alimentation . déchets . gestes . stop pub . présent: oui
     alimentation . local . consommation: "'oui toujours'"
     alimentation . plats . végétalien . nombre: 13
     alimentation . plats . végétarien . nombre: 0
@@ -641,7 +653,7 @@ personas . nadia marseille:
     transport . avion . long courrier . heures de vol:
       valeur: 14
       unité: h / an
-    alimentation . déchets . niveau d'engagement: "'affirmatif'"
+    alimentation . déchets . quantité jetée: "'base'"
     alimentation . local . consommation: "'oui toujours'"
     alimentation . plats . végétalien . nombre: 1
     alimentation . plats . végétarien . nombre: 1
@@ -668,7 +680,7 @@ personas . serge libourne:
     Adore la viande. Branché tech.
   icônes: 🥩📺
   data:
-    alimentation . déchets . niveau d'engagement: "'pas du tout'"
+    alimentation . déchets . quantité jetée: "'base'"
     alimentation . petit déjeuner . type: "'lait céréales'"
     alimentation . type de lait: "'lait de vache'"
     alimentation . boisson . sucrées . litres:

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -92,11 +92,10 @@ personas . deux tonnes:
     divers . textile . chaussure . nombre: 0
     divers . textile . manteau . nombre: 0
     divers . textile . pull . nombre: 0
-    divers . numérique . ordinateur fixe . présent: non
-    divers . numérique . TV . présent: non
-    divers . numérique . home cinéma . présent: non
-    divers . numérique . ordinateur portable . présent: non
-    divers . numérique . téléphone . type: "'téléphone basique'"
+    divers . numérique . appareils . ordinateur fixe . nombre: 0
+    divers . numérique . appareils . TV . nombre: 0
+    divers . numérique . appareils . home cinéma . nombre: 0
+    divers . numérique . appareils . ordinateur portable . nombre: 0
     divers . numérique . internet . durée journalière:
       valeur: 2
       unité: heure
@@ -171,9 +170,8 @@ personas . corentin paris:
     divers . autres produits . montant:
       valeur: 200
       unité: an
-    divers . numérique . ordinateur fixe . présent: non
-    divers . numérique . TV . présent: non
-    divers . numérique . téléphone . type: "'smartphone haut de gamme'"
+    divers . numérique . appareils . ordinateur fixe . nombre: 0
+    divers . numérique . appareils . TV . nombre: 0
     divers . numérique . internet . durée journalière:
       valeur: 8
       unité: heure
@@ -293,9 +291,8 @@ personas . sandy pacé:
     divers . textile . chaussure . nombre: 1
     divers . textile . manteau . nombre: 0
     divers . numérique . préservation: "'maximum'"
-    divers . numérique . tablette . présent: oui
-    divers . numérique . ordinateur fixe . présent: non
-    divers . numérique . téléphone . type: "'smartphone classique'"
+    divers . numérique . appareils . tablette . nombre: 1
+    divers . numérique . appareils . ordinateur fixe . nombre: 0
     divers . numérique . internet . durée journalière:
       valeur: 2
       unité: heure
@@ -386,12 +383,11 @@ personas . mehdi agen:
     divers . textile . sweat . nombre: 1
     divers . textile . chaussure . nombre: 2
     divers . textile . manteau . nombre: 1
-    divers . numérique . ordinateur fixe . présent: oui
-    divers . numérique . tablette . présent: oui
-    divers . numérique . home cinéma . présent: oui
-    divers . numérique . TV . présent: oui
+    divers . numérique . appareils . ordinateur fixe . nombre: 1
+    divers . numérique . appareils . tablette . nombre: 1
+    divers . numérique . appareils . home cinéma . nombre: 1
+    divers . numérique . appareils . TV . nombre: 1
     divers . numérique . préservation: "'achat neuf'"
-    divers . numérique . téléphone . type: "'smartphone haut de gamme'"
     divers . numérique . internet . durée journalière:
       valeur: 4
       unité: heure
@@ -505,7 +501,6 @@ personas . ximun arcangues:
     divers . textile . chaussure . nombre: 1
     divers . textile . manteau . nombre: 1
     divers . numérique . préservation: "'faible'"
-    divers . numérique . téléphone . type: "'smartphone classique'"
     divers . numérique . internet . durée journalière:
       valeur: 4
       unité: heure
@@ -661,7 +656,6 @@ personas . nadia marseille:
     divers . textile . sweat . nombre: 4
     divers . textile . chaussure . nombre: 6
     divers . textile . manteau . nombre: 6
-    divers . numérique . téléphone . type: "'smartphone haut de gamme'"
     divers . numérique . internet . durée journalière:
       valeur: 4
       unité: heure
@@ -737,15 +731,14 @@ personas . serge libourne:
     divers . textile . sweat . nombre: 1
     divers . textile . chaussure . nombre: 2
     divers . textile . manteau . nombre: 1
-    divers . numérique . ordinateur fixe . présent: oui
-    divers . numérique . tablette . présent: oui
-    divers . numérique . home cinéma . présent: oui
-    divers . numérique . TV . présent: oui
-    divers . numérique . téléphone . type: "'smartphone haut de gamme'"
+    divers . numérique . appareils . ordinateur fixe . nombre: 1
+    divers . numérique . appareils . tablette . nombre: 1
+    divers . numérique . appareils . home cinéma . nombre: 1
+    divers . numérique . appareils . TV . nombre: 1
     divers . numérique . internet . durée journalière:
       valeur: 2
       unité: heure
-    divers . numérique . appareil photo . présent: oui
+    divers . numérique . appareils . appareil photo . nombre: 1
     divers . numérique . préservation: "'faible'"
 
 personas . nolan de Neuilly:
@@ -859,20 +852,19 @@ personas . nolan de Neuilly:
     divers . textile . manteau . nombre: 2
     divers . textile . pull . nombre: 4
     divers . numérique . préservation: "'achat neuf'"
-    divers . numérique . téléphone . type: "'smartphone haut de gamme'"
-    divers . numérique . appareil photo . présent: oui
-    divers . numérique . home cinéma . présent: oui
-    divers . numérique . tablette . présent: oui
-    divers . numérique . ordinateur portable . présent: oui
-    divers . numérique . téléphone . présent: oui
-    divers . numérique . ordinateur fixe . présent: oui
-    divers . numérique . TV . présent: oui
-    divers . numérique . vidéoprojecteur . présent: oui
-    divers . numérique . enceinte bluetooth . présent: oui
-    divers . numérique . console de salon . présent: non
-    divers . numérique . montre connectée . présent: oui
-    divers . numérique . enceinte vocale . présent: oui
-    divers . numérique . console portable . présent: non
+    divers . numérique . appareils . appareil photo . nombre: 1
+    divers . numérique . appareils . home cinéma . nombre: 1
+    divers . numérique . appareils . tablette . nombre: 1
+    divers . numérique . appareils . ordinateur portable . nombre: 1
+    divers . numérique . appareils . téléphone . nombre: 1
+    divers . numérique . appareils . ordinateur fixe . nombre: 1
+    divers . numérique . appareils . TV . nombre: 1
+    divers . numérique . appareils . vidéoprojecteur . nombre: 1
+    divers . numérique . appareils . enceinte bluetooth . nombre: 1
+    divers . numérique . appareils . console de salon . nombre: 0
+    divers . numérique . appareils . montre connectée . nombre: 1
+    divers . numérique . appareils . enceinte vocale . nombre: 1
+    divers . numérique . appareils . console portable . nombre: 0
     divers . numérique . internet . durée journalière:
       valeur: 8
       unité: heure


### PR DESCRIPTION
#1784 mettait en valeur des deltas importants au niveau de certains personas, l'idée est de checker dans cette PR que ces différences sont bien liées aux changement des règles appareils `. présent` en `. nombre` mais dont le changement n'a pas été répercuté dans les personas (lié à #1791)