### PR TITLE
Référence ADEME 404 pour le textile

### DIFF
--- a/data/divers/divers . textile.yaml
+++ b/data/divers/divers . textile.yaml
@@ -30,8 +30,6 @@ divers . textile:
       - petit article
       - gros article
   unité: kgCO2e
-  références:
-    Base carbone ADEME: https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Coton_-synthetique_-autre
   description: |
     À vous de nous dire ce que vous avez mis dans vos sacs de shopping cette année, ou dans une année représentative si vous faites rarement les magasins.
 


### PR DESCRIPTION
@Clemog @Benjamin-Boisserie-ABC je me permets de supprimer cette référence cassée. 

J'ai tenté de retrouver le document rapidement, sur un nouveau lien. Peut-être aurez-vous plus de succès ? 

En attendant, je l'enlève.