### PR TITLE
On évite une division par zéro pour le nombre d'habitants

### DIFF
--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -6170,23 +6170,33 @@ divers . textile:
 
     Ne renseignez que les produits neufs. Nous excluons du calcul l'achat en friperies, la récupération, l'occasion.
   note: |
-    The data are all from the Carbon Base except for the shorts which come from the Impact Base data (textiles, household linen, leather goods) and the two generic items which are rough estimates based on the visualization of the graph of the data in the ADEME documentation
+    The data are all from the Carbon Base except for the shorts which come from the Impact Base data (textiles, household linen, leather goods) and the two generic items which are rough estimates based on the visualization of the graph of the data in the ADEME documentation. 
 
     We did not use Base Impact data (except for the shorts) because even though the data is the average of several products, many of them come from only one company.
+
+    The <a href="https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Coton_-synthetique_-autre">reference used</a> is broken, we have not (yet) found its replacement.
   note.auto: |
     The data are all from the Carbon Base except for the shorts which come from the Impact Base data (textiles, household linen, leather goods) and the two generic items which are rough estimates based on the visualization of the graph of the data in the ADEME documentation. 
 
     We did not use Base Impact data (except for the shorts) because even though the data is the average of several products, many of them come from only one company.
+
+    The <a href="https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Coton_-synthetique_-autre">reference used</a> is broken, we have not (yet) found its replacement.
   note.lock: |
     Les données sont toutes issues de la Base Carbone sauf le short qui vient des données de Base Impact (textile, linge de maison, maroquinerie) et les deux articles génériques qui sont des estimations grossières basées sur la visualisation du graphe des données de la documentation ADEME. 
 
     Nous n'avons pas utilisé les données de Base Impact (sauf dans le cas du short) car même si les données correspondent à la moyenne de plusieurs produits, beaucoup ne proviennent que d'une seule entreprise.
+
+    La [référence utilisée](https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Coton_-synthetique_-autre) est cassée, nous n'avons pas (encore) trouvé sa remplaçante.
   question: What new clothes do you usually buy in a year?
   question.auto: What new clothes do you usually buy in a year?
   question.lock: Quels vêtements achetez-vous neufs en général dans une année ?
   titre: textile
   titre.auto: textile
   titre.lock: textile
+  note.previous_review: |
+    The data are all from the Carbon Base except for the shorts which come from the Impact Base data (textiles, household linen, leather goods) and the two generic items which are rough estimates based on the visualization of the graph of the data in the ADEME documentation
+
+    We did not use Base Impact data (except for the shorts) because even though the data is the average of several products, many of them come from only one company.
 divers . textile . chaussure:
   titre: Pair of shoes
   titre.auto: Pair of shoes
@@ -17026,15 +17036,29 @@ logement . notif amortissement:
   titre.lock: notif amortissement
 logement . notif minimum habitants:
   description: |
-    The number of inhabitants cannot be zero. You are the first inhabitant
-    of your home.
+    The number of inhabitants cannot be zero or less than 1. You are the first inhabitant of your home.
+
+    Indeed, the footprint of the dwelling and other items such as appliances being divided by the number of inhabitants, it must be greater than 1.
+
+    We therefore do not take into account today the empty dwellings that you own, or a dwelling that you rent in which neither you nor anyone else lives.
   description.auto: |
-    The number of inhabitants cannot be zero. You are the first inhabitant of your home.
+    The number of inhabitants cannot be zero or less than 1. You are the first inhabitant of your home.
+
+    Indeed, the footprint of the dwelling and other items such as appliances being divided by the number of inhabitants, it must be greater than 1.
+
+    We therefore do not take into account today the empty dwellings that you own, or a dwelling that you rent in which neither you nor anyone else lives.
   description.lock: |
-    Le nombre d'habitants ne peut pas être nul. Vous êtes le premier habitant de votre logement.
+    Le nombre d'habitants ne peut pas être nul ni inférieur à 1. Vous êtes le premier habitant de votre logement.
+
+    En effet, l'empreinte du logement et d'autres postes comme l'électroménager étant divisées par le nombre d'habitant, il doit être supérieur à 1.
+
+    Nous ne prenons donc pas aujourd'hui en compte les logements vides que vous possédez, ou un logement que vous louez dans lequel ni vous ni personne ne vivez.
   titre: minimum notification inhabitants
   titre.auto: minimum notification inhabitants
   titre.lock: notif minimum habitants
+  description.previous_review: |
+    The number of inhabitants cannot be zero. You are the first inhabitant
+    of your home.
 logement . notif minimum surface:
   description: |
     The area of your home cannot be zero.
@@ -19015,24 +19039,24 @@ transport . avion . usager:
   description: |
     We have chosen to offer you the opportunity to count the impact of your air travel over several years. The footprint on the climate is such that it is important to take this into account.
 
-    So, whether you fly every year or not, answer "yes" and you will have the option to detail your travel times over the last 3 years.
+    So, whether you fly every year or not, answer "yes" and you will have the option afterwards to enter your flight times for the last 3 years.
 
     > If you flew from Paris to New York in 2021 (about 17 hours round trip), your emissions (about 2 tons) will be spread over the last 3 years.
   description.auto: |
     We have chosen to offer you the opportunity to count the impact of your air travel over several years. The footprint on the climate is such that it is important to take this into account.
 
-    So, whether you fly every year or not, answer "yes" and you will have the option to detail your travel times over the last 3 years.
+    So, whether you fly every year or not, answer "yes" and you will have the option afterwards to enter your flight times for the last 3 years.
 
     > If you flew from Paris to New York in 2021 (about 17 hours round trip), your emissions (about 2 tons) will be spread over the last 3 years.
   description.lock: |
     Nous faisons ici le choix de vous proposer de compter l'impact de vos déplacements en avion sur plusieurs années. L'empreinte sur le climat est telle qu'il est important de prendre cela en compte.
 
-    Ainsi, que vous preniez l'avion tous les ans ou non, répondez "oui" et vous aurez l'option par la suite de détailler vos temps de trajets sur les 3 dernières années.
+    Ainsi, que vous preniez l'avion tous les ans ou non, répondez "oui" et vous aurez l'option par la suite de saisir vos temps de vol des 3 dernières années.
 
     > 💡 Si vous avez pris l'avion ppour faire Paris-New-York en 2021 (environ 17h A/R), vos émissions associées (près de 2 tonnes) seront échelonnées sur les 3 dernières années.
   question: Have you flown at least once in the last 3 years?
   question.auto: Have you flown at least once in the last 3 years?
-  question.lock: Avez-vous pris l'avion au moins une fois sur les 3 dernières années ?
+  question.lock: Avez-vous pris l'avion au moins une fois ces 3 dernières années ?
   titre: user
   titre.auto: user
   titre.lock: usager
@@ -22185,3 +22209,49 @@ logement . chauffage . bois . type . granulés . prix kWh:
   titre: price kWh
   titre.auto: price kWh
   titre.lock: prix kWh
+logement . saisie habitants:
+  question: How many people live in your home?
+  question.auto: How many people live in your home?
+  question.lock: Combien de personnes vivent chez vous ?
+  titre: seizure inhabitants
+  titre.auto: seizure inhabitants
+  titre.lock: saisie habitants
+  description: |
+    We need to know how many people share your home and all the
+    consumption it entails (construction, heating, etc.).
+
+    > If you live alone, answer `1`.
+
+    > If you live with your spouse and a child, answer `3`.
+
+    > If you are separated with a child who alternates between your home and
+    > another, you can enter `1.5`.
+
+  description.auto: |
+    It is a question of knowing how many people share your home and all the consumption it entails (construction, heating, etc.).
+
+    > If you live alone, answer `1`.
+
+    > If you live with your spouse and a child, answer `3`.
+
+    > If you are separated with a child who alternates between your home and another, you can enter `1.5`.
+  description.lock: |
+    Il s'agit de savoir combien de personnes partagent votre logement et toutes les consommations qu'il entraîne (construction, chauffage, etc).
+
+    > Si vous vivez seul, répondez `1`.
+
+    > Si vous vivez avec votre conjoint et un enfant, répondez `3`.
+
+    > Si vous êtes séparé avec un enfant qui alterne entre votre logement et un autre, vous pouvez saisir `1,5`.
+  suggestions:
+    - i live alone
+    - in couple
+  suggestions.auto:
+    - i live alone
+    - in couple
+  suggestions.lock:
+    - j'habite seul
+    - en couple
+  note: default value according to https://www.insee.fr/fr/statistiques/2381486.
+  note.auto: default value according to https://www.insee.fr/fr/statistiques/2381486.
+  note.lock: valeur par défaut d'après https://www.insee.fr/fr/statistiques/2381486.

--- a/data/logement/logement.yaml
+++ b/data/logement/logement.yaml
@@ -21,7 +21,7 @@ logement . impact:
       - transport . vacances . caravane . empreinte . construction amortie
       - transport . vacances . camping car . empreinte . construction amortie
 
-logement . habitants:
+logement . saisie habitants:
   question: Combien de personnes vivent chez vous ?
   description: |
     Il s'agit de savoir combien de personnes partagent votre logement et toutes les consommations qu'il entraîne (construction, chauffage, etc).
@@ -39,12 +39,22 @@ logement . habitants:
     en couple: 2
   unité: personnes
 
+logement . habitants:
+  formule:
+    le maximum de:
+      - 1
+      - saisie habitants
+
 logement . notif minimum habitants:
   type: notification
   sévérité: invalide
-  formule: habitants = 0
+  formule: saisie habitants < 1
   description: |
-    Le nombre d'habitants ne peut pas être nul. Vous êtes le premier habitant de votre logement.
+    Le nombre d'habitants ne peut pas être nul ni inférieur à 1. Vous êtes le premier habitant de votre logement.
+
+    En effet, l'empreinte du logement et d'autres postes comme l'électroménager étant divisées par le nombre d'habitant, il doit être supérieur à 1.
+
+    Nous ne prenons donc pas aujourd'hui en compte les logements vides que vous possédez, ou un logement que vous louez dans lequel ni vous ni personne ne vivez.
 
 logement . surface:
   titre: Surface

--- a/personas/personas-en-us.yaml
+++ b/personas/personas-en-us.yaml
@@ -165,11 +165,11 @@ personas . ximun arcangues:
     Bus pour le travail. À 2 dans ferme mal isolée, chauffée au fioul. Plutôt viande.
 personas . zoé damblain:
   description: |
-    Rural. Night storekeeper in a warehouse 20 km away. No bus at night. Also takes her car for trips of -5km.
+    Rural. Night storekeeper in a warehouse 20 km away. No bus at night. Also takes her car for trips of -5km. Has a pellet stove.
   description.auto: |
-    Rural. Night storekeeper in a warehouse 20 km away. No bus at night. Also takes her car for trips of -5km.
+    Rural. Night storekeeper in a warehouse 20 km away. No bus at night. Also takes her car for trips of -5km. Has a pellet stove.
   description.lock: |
-    Rurale. Magasinière de nuit dans un entrepôt à 20 km. Pas de bus la nuit. Prend aussi sa voiture pour des trajets de -5km.
+    Rurale. Magasinière de nuit dans un entrepôt à 20 km. Pas de bus la nuit. Prend aussi sa voiture pour des trajets de -5km. Possède un poêle à granulés.
   nom: Zoé de Damblain
   nom.auto: Zoé de Damblain
   nom.lock: Zoé de Damblain

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -51,7 +51,7 @@ personas . deux tonnes:
     logement . âge:
       valeur: 100
       unité: an
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 2
       unité: personnes
     logement . climatisation . présent: non
@@ -153,7 +153,7 @@ personas . corentin paris:
     logement . surface:
       valeur: 25
       unité: m2
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 1
       unité: personnes
     logement . climatisation . présent: non
@@ -230,7 +230,7 @@ personas . sandy pacé:
     logement . surface:
       valeur: 150
       unité: m2
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 3
       unité: personnes
     logement . climatisation . présent: non
@@ -359,7 +359,7 @@ personas . mehdi agen:
     logement . surface:
       valeur: 90
       unité: m2
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 4
       unité: personnes
     logement . électricité . consommation:
@@ -470,7 +470,7 @@ personas . ximun arcangues:
     logement . surface:
       valeur: 150 #une ferme ça doit être plus grand encore mais je ne considère que la partie "ou il habite"
       unité: m2
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 2
       unité: personnes
     logement . climatisation . présent: non
@@ -697,7 +697,7 @@ personas . serge libourne:
     logement . surface:
       valeur: 150
       unité: m2
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 2
       unité: personnes
     logement . électricité . consommation:
@@ -796,7 +796,7 @@ personas . nolan de Neuilly:
     transport . vacances . caravane . propriétaire: non
     transport . vacances . maison secondaire . propriétaire: non
     transport . vacances . van . propriétaire: non
-    logement . habitants:
+    logement . saisie habitants:
       valeur: 2
       unité: personnes
     logement . âge:


### PR DESCRIPTION
Une erreur fréquente sur Sentry, qui créée une page blanche permanente
sans effacement de localstorage, d'où l'urgence.

![Recording 2023-04-21 at 13 01 45](https://user-images.githubusercontent.com/1177762/233620609-51e51802-767b-43c5-9575-4453edde62e6.gif)

Cette PR provoque une nouvelle question pour tous ceux qui avaient déjà un test rempli. 

Un exemple clair de nécessité de script de migration. 
