### PR TITLE
Bug mécanisme "le maximum de"

### DIFF
--- a/data/logement/logement.yaml
+++ b/data/logement/logement.yaml
@@ -41,9 +41,10 @@ logement . saisie habitants:
 
 logement . habitants:
   formule:
-    le maximum de:
-      - 1
-      - saisie habitants
+    variations:
+      - si: notif minimum habitants
+        alors: 1
+      - sinon: saisie habitants
 
 logement . notif minimum habitants:
   type: notification


### PR DESCRIPTION
Fix #1838 


Un bug cassant apparait lorsque l'on ajoute plusieurs chiens différents : derrière on utilise le mécanisme `recalcul`

D'un autre côté, on amorti l'empreinte des animaux via le nombre d'habitants via la variable `logement . habitants` qui utilise le mécanisme `le maximum de`

Les 2 mécanisme "couplés" semble provoquer le bug, c'est curieux ..

Studio [ici](https://publicodes.vercel.app/document/calymmien-d%C3%A9gueulasse-surfil%C3%A9?target=divers%20.%20animaux%20domestiques%20.%20empreinte)