### PR TITLE
Correction wording: Intensité "Climat" en Intensité "Carbone"

### DIFF
--- a/INTERNATIONAL.md
+++ b/INTERNATIONAL.md
@@ -39,10 +39,10 @@ Par exemple, le mix électrique est défini dans la règle `intensité électric
 
 ```yaml
 intensité électricité:
-  titre: Intensité climat du mix électrique belge
+  titre: Intensité carbone du mix électrique belge
   formule: 0.176
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 ```
 
 Sachez que le code du modèle peut contenir certaines subtilités (notamment pour la gestions des questions "Mosaïques"), n'hésitez pas à nous contacter si vous bloquez !

--- a/data/commun.yaml
+++ b/data/commun.yaml
@@ -1,5 +1,5 @@
 intensité électricité:
-  titre: Intensité climat du mix électrique français
+  titre: Intensité carbone du mix électrique français
   description: Intensité moyenne, tous types de consommations confondues, année 2021.
   formule: 0.0569
   unité: kgCO2e/kWh

--- a/data/i18n/models/BE-en-us.yaml
+++ b/data/i18n/models/BE-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Belgium
   gentilé: Belgian
 intensité électricité:
-  titre: Climate intensity of the Belgian electricity mix
+  titre: Carbon intensity of the Belgian electricity mix
   formule: 0.176
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/BE-fr.yaml
+++ b/data/i18n/models/BE-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: belge
 
 intensité électricité:
-  titre: Intensité climat du mix électrique belge
+  titre: Intensité carbone du mix électrique belge
   formule: 0.176
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/CH-en-us.yaml
+++ b/data/i18n/models/CH-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Switzerland
   gentilé: Swiss
 intensité électricité:
-  titre: Climate intensity of the Swiss electricity mix
+  titre: Carbon intensity of the Swiss electricity mix
   formule: 0.153
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . voiture . km:
   par défaut: 13430 km/an
   note: |

--- a/data/i18n/models/CH-fr.yaml
+++ b/data/i18n/models/CH-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: suisse
 
 intensité électricité:
-  titre: Intensité climat du mix électrique suisse
+  titre: Intensité carbone du mix électrique suisse
   formule: 0.153
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . voiture . km:
   par défaut: 13430 km/an

--- a/data/i18n/models/DE-en-us.yaml
+++ b/data/i18n/models/DE-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Germany
   gentilé: German
 intensité électricité:
-  titre: Climate intensity of the German electricity mix
+  titre: Carbon intensity of the German electricity mix
   formule: 0.48
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/DE-fr.yaml
+++ b/data/i18n/models/DE-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: allemande
 
 intensité électricité:
-  titre: Intensité climat du mix électrique allemand
+  titre: Intensité carbone du mix électrique allemand
   formule: 0.480
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/GF-en-us.yaml
+++ b/data/i18n/models/GF-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: Guyanese
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of the Guyanese electricity mix
+  titre: Carbon intensity of the Guyanese electricity mix
   formule: 0.957
   note: |
     We use data from the footprint database (updated in December 2020).

--- a/data/i18n/models/GF-fr.yaml
+++ b/data/i18n/models/GF-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique guyanais
+  titre: Intensité carbone du mix électrique guyanais
   formule: 0.957
   note: |
     Nous utilisons les données de la base empreinte (mise à jour en décembre 2020).

--- a/data/i18n/models/GP-en-us.yaml
+++ b/data/i18n/models/GP-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: Guadeloupean
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of the Guadeloupean electricity mix
+  titre: Carbon intensity of the Guadeloupean electricity mix
   formule: 0.702
   note: |
     We use data from the footprint database (updated in December 2020).

--- a/data/i18n/models/GP-fr.yaml
+++ b/data/i18n/models/GP-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique guadeloupéen
+  titre: Intensité carbone du mix électrique guadeloupéen
   formule: 0.702
   note: |
     Nous utilisons les données de la base empreinte (mise à jour en décembre 2020).

--- a/data/i18n/models/IT-en-us.yaml
+++ b/data/i18n/models/IT-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Italy
   gentilé: Italian
 intensité électricité:
-  titre: Climate intensity of the Italian electricity mix
+  titre: Carbon intensity of the Italian electricity mix
   formule: 0.409
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/IT-fr.yaml
+++ b/data/i18n/models/IT-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: italienne
 
 intensité électricité:
-  titre: Intensité climat du mix électrique italien
+  titre: Intensité carbone du mix électrique italien
   formule: 0.409
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/LU-en-us.yaml
+++ b/data/i18n/models/LU-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Luxembourg
   gentilé: Luxembourgish
 intensité électricité:
-  titre: Climate intensity of the Luxembourg electricity mix
+  titre: Carbon intensity of the Luxembourg electricity mix
   formule: 0.366
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/LU-fr.yaml
+++ b/data/i18n/models/LU-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: luxembourgeoise
 
 intensité électricité:
-  titre: Intensité climat du mix électrique luxembourgeois
+  titre: Intensité carbone du mix électrique luxembourgeois
   formule: 0.366
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/MQ-en-us.yaml
+++ b/data/i18n/models/MQ-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: Martiniquaise
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of Martinique's electricity mix
+  titre: Carbon intensity of Martinique's electricity mix
   formule: 0.84
   note: |
     We use data from the footprint database (updated in December 2020).

--- a/data/i18n/models/MQ-fr.yaml
+++ b/data/i18n/models/MQ-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique martiniquais
+  titre: Intensité carbone du mix électrique martiniquais
   formule: 0.840
   note: |
     Nous utilisons les données de la base empreinte (mise à jour en décembre 2020).

--- a/data/i18n/models/PF-en-us.yaml
+++ b/data/i18n/models/PF-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: Polynesian
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of the Polynesian electricity mix
+  titre: Carbon intensity of the Polynesian electricity mix
   formule:
     moyenne:
       - 0.543

--- a/data/i18n/models/PF-fr.yaml
+++ b/data/i18n/models/PF-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique polynésien
+  titre: Intensité carbone du mix électrique polynésien
   formule:
     moyenne:
       - 0.543

--- a/data/i18n/models/PL-en-us.yaml
+++ b/data/i18n/models/PL-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Poland
   gentilé: Polish
 intensité électricité:
-  titre: Climate intensity of the Polish electricity mix
+  titre: Carbon intensity of the Polish electricity mix
   formule: 0.82
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/PL-fr.yaml
+++ b/data/i18n/models/PL-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: polonaise
 
 intensité électricité:
-  titre: Intensité climat du mix électrique polonais
+  titre: Intensité carbone du mix électrique polonais
   formule: 0.820
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/PT-en-us.yaml
+++ b/data/i18n/models/PT-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Portugal
   gentilé: Portuguese
 intensité électricité:
-  titre: Climate intensity of the Portuguese electricity mix
+  titre: Carbon intensity of the Portuguese electricity mix
   formule: 0.222
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/PT-fr.yaml
+++ b/data/i18n/models/PT-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: portugaise
 
 intensité électricité:
-  titre: Intensité climat du mix électrique portugais
+  titre: Intensité carbone du mix électrique portugais
   formule: 0.222
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/RE-en-us.yaml
+++ b/data/i18n/models/RE-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: Reunionese #be careful to translation ("meeting")
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of Reunion's electricity mix
+  titre: Carbon intensity of Reunion's electricity mix
   formule: 0.78
   note: |
     We use data from the footprint database (updated in December 2020).

--- a/data/i18n/models/RE-fr.yaml
+++ b/data/i18n/models/RE-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique réunionais
+  titre: Intensité carbone du mix électrique réunionais
   formule: 0.780
   note: |
     Nous utilisons les données de la base empreinte (mise à jour en décembre 2020).

--- a/data/i18n/models/TN-en-us.yaml
+++ b/data/i18n/models/TN-en-us.yaml
@@ -6,7 +6,7 @@ params:
     - nom: Nicolas Planchenault
       url: https://github.com/nicolaspkandeel
 intensité électricité:
-  titre: Climate intensity of the Tunisian electricity mix
+  titre: Carbon intensity of the Tunisian electricity mix
   formule: 0.453
   note: |
     [Tunisia BUR3 UNFCCC](https://unfccc.int/documents/624752) GHG inventory category 1A1a, 2021

--- a/data/i18n/models/TN-fr.yaml
+++ b/data/i18n/models/TN-fr.yaml
@@ -7,7 +7,7 @@ params:
       url: https://github.com/nicolaspkandeel
 
 intensité électricité:
-  titre: Intensité climat du mix électrique tunisien
+  titre: Intensité carbone du mix électrique tunisien
   formule: 0.453
   note: |
     [Tunisia BUR3 CCNUCC](https://unfccc.int/documents/624752) Inventaire GES categorie 1A1a, 2021

--- a/data/i18n/models/TR-en-us.yaml
+++ b/data/i18n/models/TR-en-us.yaml
@@ -3,10 +3,10 @@ params:
   nom: Turkey
   gentilé: Turkish
 intensité électricité:
-  titre: Climate intensity of the Turkish electricity mix
+  titre: Carbon intensity of the Turkish electricity mix
   formule: 0.393
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/TR-fr.yaml
+++ b/data/i18n/models/TR-fr.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: turque
 
 intensité électricité:
-  titre: Intensité climat du mix électrique turc
+  titre: Intensité carbone du mix électrique turc
   formule: 0.393
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/UK-en-us.yaml
+++ b/data/i18n/models/UK-en-us.yaml
@@ -4,10 +4,10 @@ params:
   gentilé: English
   drapeau: GB
 intensité électricité:
-  titre: Climate intensity of the English electricity mix
+  titre: Carbon intensity of the United-Kingdom's electricity mix
   formule: 0.236
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 years, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) view 5 years, 2022
 transport . avion . court courrier . heures de vol:
   suggestions:
     🚫✈️: 0

--- a/data/i18n/models/UK-fr.yaml
+++ b/data/i18n/models/UK-fr.yaml
@@ -5,10 +5,10 @@ params:
   drapeau: GB
 
 intensité électricité:
-  titre: Intensité climat du mix électrique anglais
+  titre: Intensité carbone du mix électrique du Royaume-Uni
   formule: 0.236
   note: |
-    [Electricity Map](https://app.electricitymaps.com/map) vision 5 ans, 2022
+    [Electricity Map](https://app.electricitymaps.com/map) vue 5 ans, 2022
 
 transport . avion . court courrier . heures de vol:
   suggestions:

--- a/data/i18n/models/YT-en-us.yaml
+++ b/data/i18n/models/YT-en-us.yaml
@@ -4,7 +4,7 @@ params:
   gentilé: of Mayotte
   drapeau: FR
 intensité électricité:
-  titre: Climate intensity of Mayotte's electricity mix
+  titre: Carbon intensity of Mayotte's electricity mix
   formule: 0.78
   note: |
     We use data from the footprint database (updated in December 2020).

--- a/data/i18n/models/YT-fr.yaml
+++ b/data/i18n/models/YT-fr.yaml
@@ -6,7 +6,7 @@ params:
   drapeau: FR
 
 intensité électricité:
-  titre: Intensité climat du mix électrique de Mayotte
+  titre: Intensité carbone du mix électrique de Mayotte
   formule: 0.780
   note: |
     Nous utilisons les données de la base empreinte (mise à jour en décembre 2020).

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -15462,9 +15462,9 @@ intensité électricité:
     MicMac v2.6 gave a value of 12.4gCO2e/kWh for "green" electricity suppliers, but this value seems to correspond to a theoretical calculation over the year, and not to a real, minute by minute calculation.
   note.lock: |
     La v2.6 de MicMac donnait une valeur de 12.4gCO2e/kWh pour les fournisseurs d'électricité "verte", mais cette valeur semble correspondre à un calcul théorique sur l'année, et non pas à un calcul réel, minute par minute.
-  titre: Climate intensity of the French electricity mix
-  titre.auto: Climate intensity of the French electricity mix
-  titre.lock: Intensité climat du mix électrique français
+  titre: Carbon intensity of the French electricity mix
+  titre.auto: Carbon intensity of the French electricity mix
+  titre.lock: Intensité carbone du mix électrique français
 jours par an:
   titre: Number of days per year
   titre.auto: Number of days per year

--- a/data/i18n/t9n/translated-rules-es.yaml
+++ b/data/i18n/t9n/translated-rules-es.yaml
@@ -4156,7 +4156,7 @@ intensité électricité:
   note.lock: |
     La v2.6 de MicMac donnait une valeur de 12.4gCO2e/kWh pour les fournisseurs d'électricité "verte", mais cette valeur semble correspondre à un calcul théorique sur l'année, et non pas à un calcul réel, minute par minute.
   titre: Intensidad climática del mix eléctrico francés
-  titre.lock: Intensité climat du mix électrique français
+  titre.lock: Intensité carbone du mix électrique français
 logement:
   description: |
     Podemos ver nuestra vivienda como un edificio pasivo que no impactaría

--- a/data/i18n/t9n/translated-rules-it.yaml
+++ b/data/i18n/t9n/translated-rules-it.yaml
@@ -4157,7 +4157,7 @@ intensité électricité:
   note.lock: |
     La v2.6 de MicMac donnait une valeur de 12.4gCO2e/kWh pour les fournisseurs d'électricité "verte", mais cette valeur semble correspondre à un calcul théorique sur l'année, et non pas à un calcul réel, minute par minute.
   titre: Intensità climatica del mix elettrico francese
-  titre.lock: Intensité climat du mix électrique français
+  titre.lock: Intensité carbone du mix électrique français
 logement:
   description: |
     Possiamo vedere la nostra abitazione come un edificio passivo che non


### PR DESCRIPTION
## Résumé / Summary
**[EN]** i18n: Rephrase "Climate Intensity" to "Carbon intensity" and "Vision 5 years" to "View 5 years"

**[FR]** i18n: Correction de "Intensité Climat" vers "Intensité Carbone" et "Vision 5 ans" vers "Vue 5 ans"

## Explication / Rational
**[EN]** Most of the science literature and articles are using the term "Carbon Intensity" I could not find occurence of Climate Intensity elsewhere. Also, the term Vision doesn't fit with the exact type of content we are referring to, the term "view" is more appropriate.

**[FR]** La plus grande partie de la literature scientifique fait mention d'Intensité Carbone, je n'ai pas trouvé d'occurence d'Intensité Climat autre part.  Également, le terme "Vision" ne correspond pas au type de contenue auquel on réfère. Le terme "Vue" est plus approprié.
