### PR TITLE
Correction de la traduction de "plaques vitroceramiques"

### DIFF
--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -6764,33 +6764,33 @@ divers . électroménager . appareils . mini réfrigérateur . nombre:
   titre.lock: Nombre de mini réfrigérateur
 divers . électroménager . appareils . plaques:
   note: We consider electric cooktop
-  note.auto: We consider electric cooktop
+  note.auto: We consider glass-ceramic plates
   note.lock: On considère des plaques vitrocéramiques
   titre: Kichen cooktops
-  titre.auto: Cooktops
+  titre.auto: Cooking plates
   titre.lock: plaques
-  titre.previous_review: Kichen cooktops
+  titre.previous_review: Cooking plates
 divers . électroménager . appareils . plaques . durée:
   titre: Cooktop life duration
-  titre.auto: Cooktop life duration
+  titre.auto: Plate life
   titre.lock: Durée de vie plaques
 divers . électroménager . appareils . plaques . empreinte:
   note: Emission factor for cooktops from the Base Carbone (Considering electric cooktops)
-  note.auto: Emission factor for cooktops from the Base Carbone (Considering electric cooktops)
+  note.auto: Emission factor for cooktops from the Base Carbone (Considering glass-ceramic plates)
   note.lock: Facteur d'émissions plaques de la Base Carbone (On considère des plaques vitrocéramiques)
   titre: Cooktop footprint
-  titre.auto: Cooktop footprint
+  titre.auto: Plate impression
   titre.lock: Empreinte plaques
 divers . électroménager . appareils . plaques . empreinte amortie:
   titre: Reduced cooktop footprint
-  titre.auto: Reduced cooktop footprint
+  titre.auto: Cushioned plate footprint
   titre.lock: Empreinte plaques amortie
 divers . électroménager . appareils . plaques . nombre:
   question: How many cooktops do you have?
-  question.auto: How many cooktops do you have?
+  question.auto: How many plates do you have?
   question.lock: Combien de plaques possédez-vous ?
   titre: Number of cooktops
-  titre.auto: Number of cooktops
+  titre.auto: Number of plates
   titre.lock: Nombre de plaques
 divers . électroménager . appareils . robot cuisine:
   titre: Kitchen robot
@@ -15664,7 +15664,7 @@ logement . chauffage:
 
     Check all the modes you use.
   description.auto: |
-    > This question covers all the energy sources that allow you to power your heaters, water heaters, stove, etc...
+    > This question covers all the energy sources that allow you to power your heaters, water heaters, hotplates, etc...
 
     Some homes use only electricity, others are heated entirely with gas, and more rarely with wood or oil.
     In other situations, a house can be heated mainly with electric heaters or a heat pump,

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -6763,34 +6763,34 @@ divers . électroménager . appareils . mini réfrigérateur . nombre:
   titre.auto: Number of mini-fridges
   titre.lock: Nombre de mini réfrigérateur
 divers . électroménager . appareils . plaques:
-  note: We consider glass-ceramic plates
-  note.auto: We consider glass-ceramic plates
+  note: We consider electric cooktop
+  note.auto: We consider electric cooktop
   note.lock: On considère des plaques vitrocéramiques
-  titre: Cooking plates
-  titre.auto: plates
+  titre: Kichen cooktops
+  titre.auto: Cooktops
   titre.lock: plaques
-  titre.previous_review: Cooking plates
+  titre.previous_review: Kichen cooktops
 divers . électroménager . appareils . plaques . durée:
-  titre: Plate life
-  titre.auto: Plate life
+  titre: Cooktop life duration
+  titre.auto: Cooktop life duration
   titre.lock: Durée de vie plaques
 divers . électroménager . appareils . plaques . empreinte:
-  note: Emission factor for glass plates from the Base Carbone (Considering glass-ceramic plates)
-  note.auto: Emission factor for glass plates from the Base Carbone (Considering glass-ceramic plates)
+  note: Emission factor for cooktops from the Base Carbone (Considering electric cooktops)
+  note.auto: Emission factor for cooktops from the Base Carbone (Considering electric cooktops)
   note.lock: Facteur d'émissions plaques de la Base Carbone (On considère des plaques vitrocéramiques)
-  titre: Plate impression
-  titre.auto: Plate impression
+  titre: Cooktop footprint
+  titre.auto: Cooktop footprint
   titre.lock: Empreinte plaques
 divers . électroménager . appareils . plaques . empreinte amortie:
-  titre: Cushioned plate footprint
-  titre.auto: Cushioned plate footprint
+  titre: Reduced cooktop footprint
+  titre.auto: Reduced cooktop footprint
   titre.lock: Empreinte plaques amortie
 divers . électroménager . appareils . plaques . nombre:
-  question: How many plates do you have?
-  question.auto: How many plates do you have?
+  question: How many cooktops do you have?
+  question.auto: How many cooktops do you have?
   question.lock: Combien de plaques possédez-vous ?
-  titre: Number of plates
-  titre.auto: Number of plates
+  titre: Number of cooktops
+  titre.auto: Number of cooktops
   titre.lock: Nombre de plaques
 divers . électroménager . appareils . robot cuisine:
   titre: Kitchen robot
@@ -15654,7 +15654,7 @@ logement . chaudière remplacement:
   titre.lock: Passer à une chaudière bois ou à une pompe à chaleur
 logement . chauffage:
   description: |
-    > This question covers all the energy sources that allow you to power your heaters, water heaters, hotplates etc...
+    > This question covers all the energy sources that allow you to power your heaters, water heaters, stove, etc...
 
     Some homes use only electricity, others are heated entirely with gas, and more rarely with wood or oil.
     In other situations, a house can be heated mainly with electric heaters or a heat pump,
@@ -15664,7 +15664,7 @@ logement . chauffage:
 
     Check all the modes you use.
   description.auto: |
-    > This question covers all the energy sources that allow you to power your heaters, water heaters, hotplates etc...
+    > This question covers all the energy sources that allow you to power your heaters, water heaters, stove, etc...
 
     Some homes use only electricity, others are heated entirely with gas, and more rarely with wood or oil.
     In other situations, a house can be heated mainly with electric heaters or a heat pump,


### PR DESCRIPTION
## Explications
Les plaques vitroceramiques étaient traduites littéralement en "plates" hors plates signifie "assiettes" et non plaques de cuissons.

Le terme correcte étant "cooktop" ou "stove" (mais il me semble que ce dernier est plus général (inclus aussi les fours ou poêles à bois/gaz)  

## Modifications
Le terme "cooking plate" à été remplacé par "cooktop" dans la traduction anglaise