### PR TITLE
Ajout du scooter électrique dans la liste des choix de deux-roues

### DIFF
--- a/data/actions.yaml
+++ b/data/actions.yaml
@@ -31,6 +31,7 @@ actions:
       - transport . voiture 5km
       - transport . voiture électrique
       - transport . voiture . limitation autoroute
+      - transport . scooter électrique
       - divers . numérique . internet . diminuer
       - divers . partage NGC
       - divers . aider les autres

--- a/data/conversion-métrique.yaml
+++ b/data/conversion-métrique.yaml
@@ -120,7 +120,7 @@ pétrole . litres essence . voiture:
 
 pétrole . litres essence . deux roues:
   applicable si: transport . deux roues . usager
-  formule: transport . deux roues . km * transport . deux roues . empreinte
+  formule: transport . deux roues . km * transport . deux roues . conso
 
 pétrole . litres kérosène:
   applicable si: transport . avion . usager

--- a/data/conversion-métrique.yaml
+++ b/data/conversion-métrique.yaml
@@ -103,7 +103,7 @@ pétrole . litres essence:
   formule:
     somme:
       - voiture
-      - deux roues thermique
+      - deux roues
 
 pétrole . litres essence . voiture:
   non applicable si: transport . voiture . motorisation = 'électrique'
@@ -118,9 +118,9 @@ pétrole . litres essence . voiture:
       - sinon: (transport . voiture . km / transport . voiture . voyageurs) * transport . voiture . thermique . consommation au kilomètre
   unité: l
 
-pétrole . litres essence . deux roues thermique:
-  applicable si: transport . deux roues thermique . usager
-  formule: transport . deux roues thermique . km * transport . deux roues thermique . conso
+pétrole . litres essence . deux roues:
+  applicable si: transport . deux roues . usager
+  formule: transport . deux roues . km * transport . deux roues . empreinte
 
 pétrole . litres kérosène:
   applicable si: transport . avion . usager

--- a/data/i18n/models/GF-en-us.yaml
+++ b/data/i18n/models/GF-en-us.yaml
@@ -27,7 +27,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/GF-fr.yaml
+++ b/data/i18n/models/GF-fr.yaml
@@ -33,7 +33,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/GP-en-us.yaml
+++ b/data/i18n/models/GP-en-us.yaml
@@ -34,7 +34,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/GP-fr.yaml
+++ b/data/i18n/models/GP-fr.yaml
@@ -40,7 +40,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/MQ-en-us.yaml
+++ b/data/i18n/models/MQ-en-us.yaml
@@ -32,7 +32,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/MQ-fr.yaml
+++ b/data/i18n/models/MQ-fr.yaml
@@ -38,7 +38,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/PF-en-us.yaml
+++ b/data/i18n/models/PF-en-us.yaml
@@ -36,7 +36,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/PF-fr.yaml
+++ b/data/i18n/models/PF-fr.yaml
@@ -42,7 +42,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/RE-en-us.yaml
+++ b/data/i18n/models/RE-en-us.yaml
@@ -31,7 +31,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/RE-fr.yaml
+++ b/data/i18n/models/RE-fr.yaml
@@ -37,7 +37,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/YT-en-us.yaml
+++ b/data/i18n/models/YT-en-us.yaml
@@ -32,7 +32,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/models/YT-fr.yaml
+++ b/data/i18n/models/YT-fr.yaml
@@ -38,7 +38,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - métro ou tram
       - vélo

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -22847,11 +22847,11 @@ transport . deux roues . km:
   note.lock: |
     Source pour les km annuels moyens : [datalab ministère écologie 2019](https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0), figure G1-1.
 transport . deux roues:
-  titre: two wheels
+  titre: two-wheelers
   titre.auto: two wheels
   titre.lock: deux roues
 pétrole . litres essence . deux roues:
-  titre: two wheels
+  titre: two-wheelers
   titre.auto: two wheels
   titre.lock: deux roues
 transport . deux roues . type . moto inf 250:

--- a/data/i18n/t9n/translated-rules-en-us.yaml
+++ b/data/i18n/t9n/translated-rules-en-us.yaml
@@ -22840,6 +22840,12 @@ transport . deux roues . km:
   question: How many kilometers do you drive per year with your scooter or motorcycle?
   question.auto: How many kilometers do you drive per year with your scooter or motorcycle?
   question.lock: Combien de km faites-vous à l'année avec votre scooter ou moto ?
+  note: |
+    Source for average annual km: <a href="https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0">datalab ministère écologie 2019</a>, figure G1-1.
+  note.auto: |
+    Source for average annual km: <a href="https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0">datalab ministère écologie 2019</a>, figure G1-1.
+  note.lock: |
+    Source pour les km annuels moyens : [datalab ministère écologie 2019](https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0), figure G1-1.
 transport . deux roues:
   titre: two wheels
   titre.auto: two wheels
@@ -22874,29 +22880,29 @@ transport . deux roues . empreinte:
   titre.auto: footprint
   titre.lock: empreinte
   note: |
-    Moped - Mixed - 2018; 76.3 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
+    Moped - Mixed - 2018 ; 76.3 gCO2e/km/person ; ADEME calculations based on HBEFA (2020)
 
-    Electric scooter: 25 gCO2e/km/person; calculations by Anne de Bortoli for her thesis Ponts et Chaussées (2020)
+    Electric scooter: 30 gCO2e/km/person; study "Assessing the Environmental Performance of New Mobility" by the International Transport Forum. <a href="https://www.itf-oecd.org/good-to-go-environmental-performance-new-mobility">Excel available here</a>
 
     Motorcycle =&lt; 250 cm3 - Mixed - 2018; 76.3 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
 
-    Motorcycle > 250 cm3 - Mixed - 2018; 191 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
+    Motorcycle > 250 cm3 - Mixed - 2018 ; 191 gCO2e/km/person ; ADEME calculations based on HBEFA (2020)
 
-    The above figures include vehicle manufacturing, unlike the previous data (2021).
+    The above figures include vehicle manufacturing, unlike previous data (2021).
   note.auto: |
-    Moped - Mixed - 2018; 76.3 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
+    Moped - Mixed - 2018 ; 76.3 gCO2e/km/person ; ADEME calculations based on HBEFA (2020)
 
-    Electric scooter: 25 gCO2e/km/person; calculations by Anne de Bortoli for her thesis Ponts et Chaussées (2020)
+    Electric scooter: 30 gCO2e/km/person; study "Assessing the Environmental Performance of New Mobility" by the International Transport Forum. <a href="https://www.itf-oecd.org/good-to-go-environmental-performance-new-mobility">Excel available here</a>
 
     Motorcycle =&lt; 250 cm3 - Mixed - 2018; 76.3 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
 
-    Motorcycle > 250 cm3 - Mixed - 2018; 191 gCO2e/km/person; ADEME calculations based on HBEFA (2020)
+    Motorcycle > 250 cm3 - Mixed - 2018 ; 191 gCO2e/km/person ; ADEME calculations based on HBEFA (2020)
 
-    The above figures include vehicle manufacturing, unlike the previous data (2021).
+    The above figures include vehicle manufacturing, unlike previous data (2021).
   note.lock: |
     Cyclomoteur - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
-    Scooter électrique : 25 gCO2e/km/personne ; calculs Anne de Bortoli pour sa thèse Ponts et Chaussées (2020)
+    Scooter électrique : 30 gCO2e/km/personne ; étude "Assessing the Environmental Performance of New Mobility" de l'International Transport Forum. [Excel disponible ici](https://www.itf-oecd.org/good-to-go-environmental-performance-new-mobility)
 
     Moto =< 250 cm3 - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
@@ -22907,3 +22913,44 @@ transport . deux roues . type . scooter thermique:
   titre: Thermal scooter (diesel/petrol)
   titre.auto: Thermal scooter (diesel/petrol)
   titre.lock: Scooter thermique (diesel/essence)
+transport . scooter électrique:
+  titre: Switch to an electric scooter
+  titre.auto: Switch to an electric scooter
+  titre.lock: Changer pour un scooter électrique
+  description: |
+    The electric scooter isn't a miracle solution, but for certain uses it can prove (very) useful in reducing our footprint.
+
+    However, we must be careful not to reach the simplistic conclusion that switching to an electric vehicle fleet would be enough to decarbonize French travel. 
+
+    Whenever possible (55% of our journeys <a href="https://twitter.com/GlmMrt/status/1481986507179274248">are less than 5km</a>), the priority should be to promote active mobility (such as cycling) and public transport.
+
+    Nevertheless, the figure we've given you does correspond to the difference in greenhouse gas emissions that would have occurred if you had travelled your km with 
+    with an electric vehicle rather than a combustion engine.
+
+    It's also important to bear in mind that the idea here is not to encourage you to buy a new electric scooter, but rather to make your equipment last, and give preference to second-hand vehicles!
+  description.auto: |
+    The electric scooter isn't a miracle solution, but for certain uses it can prove (very) useful in reducing our footprint.
+
+    However, we must be careful not to reach the simplistic conclusion that switching to an electric vehicle fleet would be enough to decarbonize French travel. 
+
+    Whenever possible (55% of our journeys <a href="https://twitter.com/GlmMrt/status/1481986507179274248">are less than 5km</a>), the priority should be to promote active mobility (such as cycling) and public transport.
+
+    Nevertheless, the figure we've given you does correspond to the difference in greenhouse gas emissions that would have occurred if you had travelled your km with 
+    with an electric vehicle rather than a combustion engine.
+
+    It's also important to bear in mind that the idea here is not to encourage you to buy a new electric scooter, but rather to make your equipment last, and give preference to second-hand vehicles!
+  description.lock: |
+    Le scooter électrique n'est pas la solution miracle mais pour certains usages il peut s'avérer (très) utile pour réduire notre empreinte.
+
+    Attention toutefois à ne pas arriver à la conclusion simpliste qu'il suffirait de passer à un parc automobile électrique pour décarboner les déplacements des français. 
+
+    La priorité doit être, quand c'est possible (55% de nos trajets [font moins de 5km](https://twitter.com/GlmMrt/status/1481986507179274248)), l'essor des mobilités actives (telles que le vélo) et des transports en commun.
+
+    Néanmoins le chiffre que l'on vous présente correspond bien à la différence d'émissions de gaz à effet de serre qui aurait eu lieu si vous aviez parcouru vos km avec 
+    un véhicule électrique et non thermique.
+
+    Il faut également avoir en tête que l'idée ici n'est pas de pousser vers l'achat d'un scooter électrique neuf, il faut mieux faire durer son matériel et privilégier l'occasion !
+transport . scooter électrique . recalcul:
+  titre: recalculation
+  titre.auto: recalculation
+  titre.lock: recalcul

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -445,7 +445,7 @@ transport . scooter électrique:
   applicable si: 
     toutes ces conditions:
       - transport . deux roues . usager
-      - transport . deux roues . type = 'scooter électrique'
+      - transport . deux roues . type = 'scooter thermique'
   formule: transport . deux roues . empreinte - transport . scooter électrique . recalcul
 
 transport . scooter électrique . recalcul:

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -446,12 +446,12 @@ transport . scooter électrique:
     toutes ces conditions:
       - transport . deux roues . usager
       - transport . deux roues . type = 'scooter thermique'
-  formule: transport . deux roues . empreinte - transport . scooter électrique . recalcul
+  formule: transport . deux roues - transport . scooter électrique . recalcul
 
 transport . scooter électrique . recalcul:
   formule:
     recalcul:
-      règle: transport . deux roues . empreinte
+      règle: transport . deux roues
       avec:
         transport . deux roues . type: "'scooter électrique'"
 

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -442,11 +442,22 @@ transport . super ethanol . recalcul avec surconsommation:
 transport . scooter électrique:
   titre: Changer pour un scooter électrique
   icônes: 🔌🛵
-  applicable si: 
+  applicable si:
     toutes ces conditions:
       - transport . deux roues . usager
       - transport . deux roues . type = 'scooter thermique'
   formule: transport . deux roues - transport . scooter électrique . recalcul
+  description: |
+    Le scooter électrique n'est pas la solution miracle mais pour certains usages il peut s'avérer (très) utile pour réduire notre empreinte.
+
+    Attention toutefois à ne pas arriver à la conclusion simpliste qu'il suffirait de passer à un parc automobile électrique pour décarboner les déplacements des français. 
+
+    La priorité doit être, quand c'est possible (55% de nos trajets [font moins de 5km](https://twitter.com/GlmMrt/status/1481986507179274248)), l'essor des mobilités actives (telles que le vélo) et des transports en commun.
+
+    Néanmoins le chiffre que l'on vous présente correspond bien à la différence d'émissions de gaz à effet de serre qui aurait eu lieu si vous aviez parcouru vos km avec 
+    un véhicule électrique et non thermique.
+
+    Il faut également avoir en tête que l'idée ici n'est pas de pousser vers l'achat d'un scooter électrique neuf, il faut mieux faire durer son matériel et privilégier l'occasion !
 
 transport . scooter électrique . recalcul:
   formule:

--- a/data/transport/actions/transport.yaml
+++ b/data/transport/actions/transport.yaml
@@ -439,6 +439,22 @@ transport . super ethanol . taux surconsommation:
 transport . super ethanol . recalcul avec surconsommation:
   formule: recalcul * taux surconsommation
 
+transport . scooter électrique:
+  titre: Changer pour un scooter électrique
+  icônes: 🔌🛵
+  applicable si: 
+    toutes ces conditions:
+      - transport . deux roues . usager
+      - transport . deux roues . type = 'scooter électrique'
+  formule: transport . deux roues . empreinte - transport . scooter électrique . recalcul
+
+transport . scooter électrique . recalcul:
+  formule:
+    recalcul:
+      règle: transport . deux roues . empreinte
+      avec:
+        transport . deux roues . type: "'scooter électrique'"
+
 transport . voiture électrique:
   titre: Acheter une voiture électrique
   icônes: 🔌🚗

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -19,7 +19,7 @@ transport . empreinte:
     somme:
       - voiture . empreinte
       - avion
-      - deux roues thermique
+      - deux roues
       - bus
       - train
       - métro ou tram
@@ -227,45 +227,50 @@ transport . vélo . km:
   par défaut: 5 km
   note: Le chiffre par défaut est une grossière estimation sans source, mais peu importe vu l'impact final nul.
 
-transport . deux roues thermique:
+transport . deux roues:
   icônes: 🛵
   applicable si: usager
   formule: empreinte * km
 
-transport . deux roues thermique . usager:
+transport . deux roues . usager:
   question: Utilisez-vous un scooter ou une moto ?
   description: |
-    Les scooters et motos sont aujourd'hui très majoritairement des engins qui fonctionnent au pétrole. Les équivalents électriques ont fait leur apparition, mais timidement.
+    Les scooters et motos sont aujourd'hui très majoritairement des engins qui fonctionnent au pétrole. Les scooters électriques ayant fait une réelle percée, ils sont ajoutés au modèle.
   par défaut: non
 
-transport . deux roues thermique . km:
+transport . deux roues . km:
   question: Combien de km faites-vous à l'année avec votre scooter ou moto ?
-  par défaut: 1000 km
+  par défaut: 3000 km
 
-transport . deux roues thermique . type:
-  question: Quel type de deux roues thermique utilisez-vous ?
-  applicable si: usager
-  par défaut: "'scooter'"
+transport . deux roues . type:
+  question: Quel type de deux-roues utilisez-vous ?
+  par défaut: "'scooter thermique'"
   formule:
-    une possibilité:
-      choix obligatoire: oui
-      possibilités:
-        - scooter
-        - moto inf 250
-        - moto sup 250
+      une possibilité:
+        choix obligatoire: oui
+        possibilités:
+          - scooter thermique
+          - scooter électrique
+          - moto inf 250
+          - moto sup 250
 
-transport . deux roues thermique . type . scooter:
-  titre: Scooter
-transport . deux roues thermique . type . moto inf 250:
-  titre: Moto moins de 250 cm3
-transport . deux roues thermique . type . moto sup 250:
-  titre: Moto plus de 250 cm3
+transport . deux roues . type . scooter thermique:
+  titre: Scooter thermique (diesel/essence)
+transport . deux roues . type . scooter électrique:
+  titre: Scooter électrique
+transport . deux roues . type . moto inf 250:
+  titre: Moto de moins de 250 cm3
+transport . deux roues . type . moto sup 250:
+  titre: Moto de plus de 250 cm3
 
-transport . deux roues thermique . empreinte:
+transport . deux roues . empreinte:
+  unité: kgCO2e/km
   formule:
     variations:
-      - si: type = 'scooter'
+      - si: type = 'scooter thermique'
         alors: 0.0763 kgCO2e/km
+      - si: type = 'scooter électrique'
+        alors: 0.025 kgCO2e/km
       - si: type = 'moto inf 250'
         alors: 0.0763 kgCO2e/km
       - si: type = 'moto sup 250'
@@ -274,23 +279,13 @@ transport . deux roues thermique . empreinte:
   note: |
     Cyclomoteur - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
+    Scooter électrique : 25 gCO2e/km/personne ; calculs Anne de Bortoli pour sa thèse Ponts et Chaussées (2020)
+
     Moto =< 250 cm3 - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
     Moto > 250 cm3 - Mixte - 2018 ; 191 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
-
 
     Les chiffres ci-dessus incluent la fabrication du véhicule, contrairement aux données précédentes (2021).
 
   références:
     documentation bilan-GES: https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm
-
-transport . deux roues thermique . conso:
-  formule:
-    variations:
-      - si: type = 'scooter'
-        alors: 2.3 / 100 l/km
-      - si: type = 'moto inf 250'
-        alors: 2.2 / 100 l/km
-      - si: type = 'moto sup 250'
-        alors: 6 / 100 l/km
-  note: Données issues de HBEFA selon la documentation de la base carbone (https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm)

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -240,7 +240,8 @@ transport . deux roues . usager:
 
 transport . deux roues . km:
   question: Combien de km faites-vous à l'année avec votre scooter ou moto ?
-  par défaut: 3000 km
+  par défaut: 3000
+  unité: km
   note: |
     Source pour les km annuels moyens : [datalab ministère écologie 2019](https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0), figure G1-1.
 

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -241,6 +241,8 @@ transport . deux roues . usager:
 transport . deux roues . km:
   question: Combien de km faites-vous à l'année avec votre scooter ou moto ?
   par défaut: 3000 km
+  note: |
+    Source pour les km annuels moyens : [datalab ministère écologie 2019](https://www.statistiques.developpement-durable.gouv.fr/bilan-annuel-des-transports-en-2019-0), figure G1-1.
 
 transport . deux roues . type:
   question: Quel type de deux-roues utilisez-vous ?

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -290,10 +290,12 @@ transport . deux roues . empreinte:
   références:
     documentation bilan-GES: https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm
 
-  transport . deux roues thermique . conso:
+transport . deux roues . conso:
   formule:
     variations:
-      - si: type = 'scooter'
+      - si: type = 'scooter électrique'
+        alors: 0 / 100 l/km
+      - si: type = 'scooter thermique'
         alors: 2.3 / 100 l/km
       - si: type = 'moto inf 250'
         alors: 2.2 / 100 l/km

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -289,3 +289,14 @@ transport . deux roues . empreinte:
 
   références:
     documentation bilan-GES: https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm
+
+  transport . deux roues thermique . conso:
+  formule:
+    variations:
+      - si: type = 'scooter'
+        alors: 2.3 / 100 l/km
+      - si: type = 'moto inf 250'
+        alors: 2.2 / 100 l/km
+      - si: type = 'moto sup 250'
+        alors: 6 / 100 l/km
+  note: Données issues de HBEFA selon la documentation de la base carbone (https://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?routier2.htm)

--- a/data/transport/transport.yaml
+++ b/data/transport/transport.yaml
@@ -272,7 +272,7 @@ transport . deux roues . empreinte:
       - si: type = 'scooter thermique'
         alors: 0.0763 kgCO2e/km
       - si: type = 'scooter électrique'
-        alors: 0.025 kgCO2e/km
+        alors: 0.030 kgCO2e/km
       - si: type = 'moto inf 250'
         alors: 0.0763 kgCO2e/km
       - si: type = 'moto sup 250'
@@ -281,7 +281,7 @@ transport . deux roues . empreinte:
   note: |
     Cyclomoteur - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 
-    Scooter électrique : 25 gCO2e/km/personne ; calculs Anne de Bortoli pour sa thèse Ponts et Chaussées (2020)
+    Scooter électrique : 30 gCO2e/km/personne ; étude "Assessing the Environmental Performance of New Mobility" de l'International Transport Forum. [Excel disponible ici](https://www.itf-oecd.org/good-to-go-environmental-performance-new-mobility)
 
     Moto =< 250 cm3 - Mixte - 2018 ; 76,3 gCO2e/km/personne ; calculs ADEME à partir d'HBEFA (2020)
 

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -34,7 +34,7 @@ personas . deux tonnes:
     transport . voiture . km:
       valeur: 0
       unité: km / an
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 0
@@ -136,7 +136,7 @@ personas . corentin paris:
     transport . voiture . saisie voyageurs:
       valeur: 4
       unité: voyageurs
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: oui
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 1
@@ -269,7 +269,6 @@ personas . sandy pacé:
       unité: l / centkm
     transport . vacances . caravane . propriétaire: oui
     transport . vacances . caravane . distance: 8000
-    transport . deux roues thermique . usager: non
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 0
@@ -342,7 +341,7 @@ personas . mehdi agen:
     transport . voiture . thermique . consommation aux 100:
       valeur: 7
       unité: l / centkm
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 0
@@ -436,7 +435,7 @@ personas . ximun arcangues:
     transport . voiture . thermique . consommation aux 100:
       valeur: 7
       unité: l / centkm
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: oui
     transport . avion . court courrier . heures de vol:
       valeur: 0
@@ -548,7 +547,7 @@ personas . jessica lyon:
       unité: km / an
     transport . voiture . propriétaire: oui
     transport . voiture . âge: 10
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: oui
     transport . avion . court courrier . heures de vol:
       valeur: 8
@@ -592,7 +591,7 @@ personas . zoé damblain:
     transport . voiture . thermique . consommation aux 100:
       valeur: 7
       unité: l / centkm
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 0
@@ -637,7 +636,7 @@ personas . nadia marseille:
     transport . voiture . thermique . consommation aux 100:
       valeur: 10
       unité: l / centkm
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: oui
     transport . avion . court courrier . heures de vol:
       valeur: 8
@@ -769,7 +768,7 @@ personas . nolan de Neuilly:
     transport . voiture . thermique . consommation aux 100:
       valeur: 11
       unité: l / centkm
-    transport . deux roues thermique . usager: non
+    transport . deux roues . usager: non
     transport . avion . usager: oui
     transport . avion . court courrier . heures de vol:
       valeur: 20

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -516,7 +516,7 @@ personas . ximun arcangues:
 personas . marie laval:
   nom: Marie de Laval
   description: |
-    Grande amatrice de viande et de bière. Boit de l'eau en bouteille et aime la boisson.
+    Grande amatrice de viande et de bière. Boit de l'eau en bouteille et aime la boisson. Elle possède une moto pour bouger les week-ends mais pas de voiture.
   icônes: 🚗🥩
   data:
     alimentation . déchets . quantité jetée: "'base'"
@@ -535,6 +535,11 @@ personas . marie laval:
     alimentation . plats . végétalien . nombre: 0
     alimentation . plats . poisson 1 . nombre: 0
     alimentation . plats . poisson 2 . nombre: 0
+    transport . voiture . km: 2000
+    transport . voiture . propriétaire: non
+    transport . deux roues . usager: oui
+    transport . deux roues . type: "'moto sup 250'"
+    transport . deux roues . km: 12000
 
 personas . jessica lyon:
   nom: Jessica de Lyon
@@ -881,7 +886,7 @@ personas . nolan de Neuilly:
 personas . eric strasbourg:
   nom: Eric de Strasbourg
   résumé: |
-    Profil urbain, logement collectif en appartement.
+    Profil urbain, logement collectif en appartement. Eric possède également un scooter électrique pour ses déplacements quotidiens.
   description: |
     Pourrait être raccordé à un réseau de chaleur.
   icônes: 👥🔥
@@ -897,3 +902,6 @@ personas . eric strasbourg:
     logement . chauffage . gaz . biogaz: non
     logement . chauffage . gaz . consommation: 5000
     logement . électricité . consommation: 2000
+    transport . deux roues . usager: oui
+    transport . deux roues . type: "'scooter électrique'"
+    transport . deux roues . km: 2000

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -138,9 +138,7 @@ personas . corentin paris:
       unité: voyageurs
     transport . deux roues . usager: oui
     transport . deux roues . type: "'scooter thermique'"
-    transport . deux roues . km: 
-      valeur: 3000
-      unité: km / an
+    transport . deux roues . km: 3000
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 1

--- a/personas/personas-fr.yaml
+++ b/personas/personas-fr.yaml
@@ -103,7 +103,7 @@ personas . deux tonnes:
 personas . corentin paris:
   nom: Corentin de Paris
   description: |
-    Presque zéro voiture, vit seul dans un studio au gaz, presque végétarien.
+    Presque zéro voiture, scooter thermique, vit seul dans un studio au gaz, presque végétarien.
   icônes: 🛴🏢
   data:
     alimentation . déchets . quantité jetée: "'réduction'"
@@ -137,6 +137,10 @@ personas . corentin paris:
       valeur: 4
       unité: voyageurs
     transport . deux roues . usager: oui
+    transport . deux roues . type: "'scooter thermique'"
+    transport . deux roues . km: 
+      valeur: 3000
+      unité: km / an
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 1
@@ -269,6 +273,7 @@ personas . sandy pacé:
       unité: l / centkm
     transport . vacances . caravane . propriétaire: oui
     transport . vacances . caravane . distance: 8000
+    transport . deux roues . usager: non
     transport . avion . usager: non
     transport . bus . heures par semaine:
       valeur: 0


### PR DESCRIPTION
Répond en partie à #966 et à #1884.

Fait : ajout de l'option "scooter électrique" parmi les choix de deux-roues motorisés.
Modification du nombre de km / défaut pour les motos.

Reste à faire : 

- [x] Vérification des FE
- [x] Retravailler les personas
- [x] Traduction