### PR TITLE
Fix: better error message in the CI when the rulesToJSON fails at parsing

### DIFF
--- a/scripts/rulesToJSON.mjs
+++ b/scripts/rulesToJSON.mjs
@@ -71,6 +71,16 @@ function getTranslatedRules(baseRules, destLang) {
 	return addTranslationToBaseRules(baseRules, translatedAttrs)
 }
 
+function logPublicodesError(err) {
+	let lines = err.message.split('\n')
+	for (let i = 0; i < 9; ++i) {
+		if (lines[i]) {
+			console.error('  ', lines[i])
+		}
+	}
+	console.error('')
+}
+
 /// ---------------------- Main ----------------------
 
 if (markdown) {
@@ -92,22 +102,11 @@ try {
 	new Engine(baseRules, {
 		// NOTE(@EmileRolley): warnings are ignored for now but should be examined in
 		//    https://github.com/datagir/nosgestesclimat/issues/1722
-		logger: { log: (_) => {}, warn: (_) => {}, err: (s) => console.error(s) },
+		logger: { log: (_) => {}, warn: (_) => {}, err: (_) => {} },
 	})
-	console.log(
-		markdown
-			? `| Rules evaluation | :heavy_check_mark: | Ø |`
-			: ' ✅ Base rules have been correctly evaluated'
-	)
 } catch (err) {
-	console.log(' ❌ An error occured while trying to evaluate the rules:\n')
-	let lines = err.message.split('\n')
-	for (let i = 0; i < 9; ++i) {
-		if (lines[i]) {
-			console.log('  ', lines[i])
-		}
-	}
-	console.log(err)
+	console.error(` ❌ An error occured while trying to parse the base rules:\n`)
+	logPublicodesError(err)
 	exit(-1)
 }
 


### PR DESCRIPTION
Fixes #1889 by logging the [compilation error](https://github.com/datagir/nosgestesclimat/actions/runs/5066606513/jobs/9096618380?pr=1890) in the CI output and by compiling rules before running personas and optim tests:

![Screenshot from 2023-05-24 11-01-08](https://github.com/datagir/nosgestesclimat/assets/44124798/ccbbd909-8fef-475f-b6dd-b446f42dfc51)
