### PR TITLE
Ajout ferry transport régions outre-mer

### DIFF
--- a/data/i18n/models/GF-en-us.yaml
+++ b/data/i18n/models/GF-en-us.yaml
@@ -32,3 +32,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/GF-fr.yaml
+++ b/data/i18n/models/GF-fr.yaml
@@ -38,3 +38,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/GP-en-us.yaml
+++ b/data/i18n/models/GP-en-us.yaml
@@ -39,3 +39,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/GP-fr.yaml
+++ b/data/i18n/models/GP-fr.yaml
@@ -45,3 +45,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/MQ-en-us.yaml
+++ b/data/i18n/models/MQ-en-us.yaml
@@ -37,3 +37,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/MQ-fr.yaml
+++ b/data/i18n/models/MQ-fr.yaml
@@ -43,3 +43,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/PF-en-us.yaml
+++ b/data/i18n/models/PF-en-us.yaml
@@ -41,3 +41,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/PF-fr.yaml
+++ b/data/i18n/models/PF-fr.yaml
@@ -47,3 +47,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/RE-en-us.yaml
+++ b/data/i18n/models/RE-en-us.yaml
@@ -36,3 +36,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/RE-fr.yaml
+++ b/data/i18n/models/RE-fr.yaml
@@ -42,3 +42,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/YT-en-us.yaml
+++ b/data/i18n/models/YT-en-us.yaml
@@ -37,3 +37,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry

--- a/data/i18n/models/YT-fr.yaml
+++ b/data/i18n/models/YT-fr.yaml
@@ -43,3 +43,4 @@ transport . empreinte:
       - métro ou tram
       - vélo
       - vacances
+      - ferry


### PR DESCRIPTION
L'ajout du ferry n'avait pas été répercuté dans les modèles outre-mer dans lesquels nous avions réécrit la formule de `transport . empreinte` pour éliminer le train.

(ping @JuliePouliquen)