### PR TITLE
Un attribut vide ne doit pas être traduit

### DIFF
--- a/scripts/i18n/utils.js
+++ b/scripts/i18n/utils.js
@@ -196,10 +196,13 @@ const getMissingRules = (srcRules, targetRules) => {
 			if (targetRule) {
 				acc.push(
 					filteredValEntries.reduce((acc, [attr, refVal]) => {
+						if (refVal === null) {
+							// The attribute value can be `null` for imported models (importer! mechanism), it should not be translated.
+							return acc
+						}
 						if (mechanismsToTranslate.includes(attr)) {
 							let targetRef = targetRule[attr + LOCK_KEY_EXT]
 							let hasTheSameRefValue
-
 							switch (attr) {
 								case 'suggestions': {
 									refVal = Object.keys(refVal)


### PR DESCRIPTION
Petit pb au niveau des scripts de traduction suite à l'ajout du ferry ou nous avons intriduit une subtilité sur la possibilité d'écraser un attribut du modèle source avec une valeur `null` (c'est le cas pour les questions que l'on ne souhaite pas afficher dans le test). Le fix ici permet de ne pas passer ces attributs dans les règles à traduire.
Dans le modèle, c'est néanmoins impossible *de base* d'avoir un attribut vide donc je ne sais pas comment on souhaite gérer ce cas particulier